### PR TITLE
Replaced riptano references with apache github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ script:
   # we use flake8 because it allows us to ignore other warnings
   # exclude the thrift directories - they contain auto-generated code
   - flake8 --ignore=E501,F811,F812,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindings,cassandra-thrift .
-  - git remote add riptano git://github.com/riptano/cassandra-dtest.git
-  - git fetch riptano # fetch master for the next diff
+  - git remote add apache git://github.com/apache/cassandra-dtest.git
+  - git fetch apache # fetch master for the next diff
   # feed changed lines with no context around them to pep8
   # I know we don't enforce line length but if you introduce
   # 200-char lines you are doing something terribly wrong.
   # lint all files for everything but line length errors
-  - git diff riptano/master...HEAD -U0 | pep8 --ignore=E501 --diff
+  - git diff apache/master...HEAD -U0 | pep8 --ignore=E501 --diff
   # lint all files except json_test.py for line length errors
-  - git diff riptano/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --exclude='meta_tests/assertion_test.py' --max-line-length=200
+  - git diff apache/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --exclude='meta_tests/assertion_test.py' --max-line-length=200
 sudo: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ In some cases, we organize our test files by putting them in directories. If you
 
 ## Assertions
 
-- When possible, you should use the assert functions from [`tools/assertions.py`](https://github.com/riptano/cassandra-dtest/blob/master/tools/assertions.py).
+- When possible, you should use the assert functions from [`tools/assertions.py`](https://github.com/apache/cassandra-dtest/blob/master/tools/assertions.py).
 - When none of these are applicable, use python's built in [unittest assertions](https://docs.python.org/2/library/unittest.html#assert-methods).
 - Naked assert statements should never be used, e.g. `assert True`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ will often need to modify them in some fashion at some later point:
 * cassandra-dtest
 
         cd ~/git/cstar
-        git clone git://github.com/riptano/cassandra-dtest.git
+        git clone git://github.com/apache/cassandra-dtest.git
 
 * nose
 

--- a/linter_check.sh
+++ b/linter_check.sh
@@ -7,11 +7,11 @@ flake8 --ignore=E501,F811,F812,F822,F823,F831,F841,N8,C9 --exclude=thrift_bindin
 flake8_result=$?
 
 # lint all files for everything but line length errors
-git diff riptano/master...HEAD -U0 | pep8 --ignore=E501 --diff
+git diff apache/master...HEAD -U0 | pep8 --ignore=E501 --diff
 pep8_style_check=$?
 
 # lint all files except json_test.py for line length errors
-git diff riptano/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --exclude='meta_tests/assertion_test.py' --max-line-length=200
+git diff apache/master...HEAD -U0 | pep8 --diff --exclude='json_test.py' --exclude='meta_tests/assertion_test.py' --max-line-length=200
 pep8_line_length=$?
 
 echo -e "\nflake8 exited with ${flake8_result}."


### PR DESCRIPTION
I think these references, minus the ones in documentations, are unused anyway so it shouldn't cause any issues to update.