### PR TITLE
Install ccm from github branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 futures
 six
 -e git+https://github.com/datastax/python-driver.git@cassandra-test#egg=cassandra-driver
-ccm==3.1.0
+# Used ccm version is tracked by a ccm git branch. Please create a PR there for fixes or upgrades to new releases.
+-e git+https://github.com/pcmanus/ccm.git@cassandra-test#egg=ccm
 cql
 decorator
 docopt


### PR DESCRIPTION
Recently we had some ccm related issues with our dtest suite. In this case, it would be convenient to be able to merge dtest fixes into a separate branch on the ccm side and have dtests pick up the updated version automatically. This already happens with the python driver and I don't think has been an issue so far. WDYT @mambocab , @ptnapoleon ?