### PR TITLE
tools/jmxutils.py decode bytes to string before passing to json.loads

### DIFF
--- a/tools/jmxutils.py
+++ b/tools/jmxutils.py
@@ -22,7 +22,7 @@ def jolokia_classpath():
         return CLASSPATH_SEP.join((tools_jar, JOLOKIA_JAR))
     else:
         logger.warning("Environment variable $JAVA_HOME not present: jmx-based " +
-                "tests may fail because of missing $JAVA_HOME/lib/tools.jar.")
+                       "tests may fail because of missing $JAVA_HOME/lib/tools.jar.")
         return JOLOKIA_JAR
 
 
@@ -237,7 +237,7 @@ class JolokiaAgent(object):
             raise Exception("Failed to query Jolokia agent; HTTP response code: %d; response: %s" % (response.code, response.readlines()))
 
         raw_response = response.readline()
-        response = json.loads(raw_response)
+        response = json.loads(raw_response.decode(encoding='utf-8'))
         if response['status'] != 200:
             stacktrace = response.get('stacktrace')
             if stacktrace and verbose:


### PR DESCRIPTION
See CASSANDRA-14320 - addresses TypeError raised by calling json.loads on bytes without decoding to string, also fixes a visual indent for PEP-8 compliance in the same file.

Result of this change can be seen easily by running the deprecated repair tests (repair_tests/deprecated_repair_test.py) with and without this modification.