### PR TITLE
Fix since_version for seed tests

### DIFF
--- a/seed_test.py
+++ b/seed_test.py
@@ -12,7 +12,7 @@ class TestGossiper(Tester):
     Test gossip states
     """
 
-    @since('3.11.2')
+    @since('3.11.3')
     def test_startup_no_live_seeds(self):
         """
         Test that a node won't start with no live seeds.
@@ -42,7 +42,7 @@ class TestGossiper(Tester):
         else:
             pytest.fail("Expecting startup to raise a TimeoutError, but nothing was raised.")
 
-    @since('3.11.2')
+    @since('3.11.3')
     def test_startup_non_seed_with_peers(self):
         """
         Test that a node can start if peers are alive, or if a node has been bootstrapped
@@ -83,7 +83,7 @@ class TestGossiper(Tester):
         node1.start(wait_other_notice=False, wait_for_binary_proto=120)
         self.assert_log_had_msg(node1, 'Unable to gossip with any peers but continuing anyway since node is in its own seed list', timeout=60)
 
-    @since('3.11.2')
+    @since('3.11.3')
     def test_startup_after_ring_delay(self):
         """
         Tests that if we start a node with no live seeds, then start a seed after RING_DELAY


### PR DESCRIPTION
Change only went in for 3.11.3, was meant to update but forgot :/.