### PR TITLE
from plugins.assert_tools import assert_regexp_matches

### DIFF
--- a/auth_join_ring_false_test.py
+++ b/auth_join_ring_false_test.py
@@ -4,6 +4,7 @@ from cassandra import AuthenticationFailed, Unauthorized
 from cassandra.cluster import NoHostAvailable
 
 from dtest import Tester
+from plugins.assert_tools import assert_regexp_matches
 
 
 class TestAuth(Tester):


### PR DESCRIPTION
flake8 testing of https://github.com/apache/cassandra-dtest on Python 3.6.3
$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./auth_join_ring_false_test.py:188:13: F821 undefined name 'assert_regexp_matches'
            assert_regexp_matches(repr(cm._excinfo[1]), message)
            ^
```