### PR TITLE
Introduce tox and (optional) pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ last_test_dir
 upgrade
 html/
 doxygen/doxypy-0.4.2/
+
+.tox
+.pytest_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  sha: v2.0.0
+  hooks:
+    - id: trailing-whitespace
+    - id: flake8
+      args: ['--ignore=E501,F811,F812,F822,F823,F831,F841,N8,C9']
+      exclude: ^thrift_bindings|^cassandra-thrift
+- repo: https://github.com/asottile/reorder_python_imports.git
+  sha: v1.3.3
+  hooks:
+    - id: reorder-python-imports
+      exclude: ^thrift_bindings|^cassandra-thrift

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+[tox]
+project=
+skipsdist=True
+
+[testenv]
+deps =
+    -rrequirements.txt
+
+[testenv:pre-commit]
+basepython = python3
+envdir = .tox/pre-commit
+deps = pre-commit
+commands =
+    pre-commit install -f --install-hooks
+
+[testenv:pre-commit-test]
+basepython = python3
+envdir = .tox/pre-commit
+deps = pre-commit
+commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
+
+[testenv:pre-commit-remove]
+basepython = python3
+envdir = .tox/pre-commit
+deps = pre-commit
+commands =
+    pre-commit uninstall
+
+[testenv:pytest]
+basepython = python3
+envdir = .tox/dtest
+commands =
+    pytest {posargs}
+
+[testenv:dtest]
+basepython = python3
+envdir = .tox/dtest
+commands =
+    ./run_dtests.py {posargs}


### PR DESCRIPTION
I think we can remove some of the complexity around building/running dtests by introducing [tox](https://tox.readthedocs.io/en/latest/) support and we can remove some of the confusion about python style using [pre-commit](https://pre-commit.com/)

`tox` is a pretty industry standard way to manage virtualenvs so that users don't have to think about how to properly setup virtualenvs and install dependencies and the such.

Devs don't need to enter virtualenvs or worry about any of that, they can just do:
```
tox -e pytest -- --cassandra-dir=<cassandra dir> -k <the test name they want to run>
```
and tox takes care of creating a virtualenv with the proper version of python, installing the requirements, and executing pytest (anything after the -- is passed directly to pytest).

I've also included a `dtest` target for using the run_test helper script if someone wants to, e.g.
```
tox -e dtest -- --cassandra-dir=/home/josephl/pg/cassandra_trunk --dtest-tests=topology_test.py
```

Along with adding tox I've also added optional pre-commit hooks that people can install via the `pre-commit` or `pre-commit-test` tox targets. If a dev chooses to install them we will install (and later re-use) linting pre-commit hooks that will do things like check flake8 compliance, ensure that imports are sorted and in the proper order and we can do much more (there are a [lot of hooks](https://pre-commit.com/hooks.html) we can run if we want). These checks happen incrementally on each file as it is committed so that no new style violations are introduced and over time we make progress on improving the code quality. Once the whole code base is up to snuff we could even introduce a call to `tox -e pre-commit` to force the linters to run on all files at PR time to replace the current `.travis.yaml` system.  For example once the hooks are installed via a run of `tox -e pytest` or `tox -e dtest`:
```bash
$ tox -e pre-commit

# Now someone tries to add an incorrect style file
$ cat foo.py 
import zlib
import itertools

def bad(x):
    print('too close');

def form(y):
    bad(x = 2)

$ git commit -m "Test"
Trim Trailing Whitespace.................................................Passed
Flake8...................................................................Failed
hookid: flake8

foo.py:1:1: F401 'zlib' imported but unused
foo.py:2:1: F401 'itertools' imported but unused
foo.py:4:1: E302 expected 2 blank lines, found 1
foo.py:5:23: E703 statement ends with a semicolon
foo.py:7:1: E302 expected 2 blank lines, found 1
foo.py:8:10: E251 unexpected spaces around keyword / parameter equals
foo.py:8:12: E251 unexpected spaces around keyword / parameter equals
foo.py:9:1: W391 blank line at end of file

Reorder python imports...................................................Failed
hookid: reorder-python-imports

Files were modified by this hook. Additional output:

Reordering imports in foo.py
```
Now the user has clear indications where their code does not meet expectations.

They can also skip the hooks if they want:
```
git commit --no-verify
```

or they can uninstall them:
```
tox -e pre-commit-remove
```