### PR TITLE
Fix token_generator_test for Cassandra 2.2

### DIFF
--- a/token_generator_test.py
+++ b/token_generator_test.py
@@ -40,7 +40,7 @@ class TestTokenGenerator(Tester):
             args.append(str(n))
 
         logger.debug('Invoking {}'.format(args))
-        token_gen_output = subprocess.check_output(args)
+        token_gen_output = subprocess.check_output(args).decode()
         lines = token_gen_output.split("\n")
         dc_tokens = None
         generated_tokens = []


### PR DESCRIPTION
In python 3 subprocess returns bytes, so just decode them.

Needed for https://issues.apache.org/jira/browse/CASSANDRA-15012