### PR TITLE
CASSANDRA-15052 added acceptable warnings to offline tool tests in order to pass them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ last_test_dir
 upgrade
 html/
 doxygen/doxypy-0.4.2/
+.pytest_cache

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -445,7 +445,7 @@ class TestOfflineTools(Tester):
         assert {'1', '2'} == dumped_keys
 
     def _check_stderr_error(self, error):
-        acceptable = ["Max sstable size of", "Consider adding more capacity", "JNA link failure", "Class JavaLaunchHelper is implemented in both"]
+        acceptable = ["Max sstable size of", "Consider adding more capacity", "JNA link failure", "Class JavaLaunchHelper is implemented in both", "Small commitlog volume detected", "Small cdc volume detected"]
 
         if len(error) > 0:
             for line in error.splitlines():


### PR DESCRIPTION
Some tests in offline_tools_py (eg offline_tools_test.py::TestOfflineTools::test_sstablelevelreset) )were failing because of unexpected warnings which occurred here.

There is already a way how to ignore warnings, I have just added more of them into the array so test passes fine.

@dineshjoshi @jolynch Could you please review this? I am trying to figure out who to contact in order to merge this so it is not hanging here for ever.

Thanks!