### PR TITLE
fixed flakey tests in  replication_test.py CASSANDRA-15605

### DIFF
--- a/replication_test.py
+++ b/replication_test.py
@@ -348,7 +348,7 @@ class TestSnitchConfigurationUpdate(Tester):
                     m = regex.match(line)
                     if m:
                         racks.append(m.group(1))
-
+                racks.sort() #order is not deterministic
                 if racks == expected_racks:
                     # great, the topology change is propagated
                     logger.debug("Topology change detected on node {}".format(i))


### PR DESCRIPTION
nodetool status output was not always in the order expected by the test, since the check is a simple comparison this means we were getting failures even when the test otherwise succeeded.

fails

```
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack
UN  127.0.0.3  105.28 KiB  1       ?                 41df89ae-0631-447c-9def-ff1fbff3b8a7  rack2
UN  127.0.0.2  164.25 KiB  1       ?                 47a49e4e-6964-4b00-b353-d3ab345f4aba  rack1
UN  127.0.0.1  128.46 KiB  1       ?                 b63ad12d-1d12-4e51-95ba-88ff61b252ea  rack0
```

works

```
16:05:35,630 replication_test DEBUG Datacenter: dc1 
===============
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack
UN  127.0.0.1  132.51 KiB  1       100.0%            8b244cb0-135d-4745-b498-86f46187348f  rack0
UN  127.0.0.2  164.36 KiB  1       100.0%            36f42f34-fe8c-4543-b6c9-6db12b93b660  rack1
UN  127.0.0.3  192.66 KiB  1       100.0%            1224e768-db1f-4d56-a1c8-db9b764a46d5  rack2
```

fix is a one liner where I add a sort to the racks output and I can't get the tests to fail now.