### PR TITLE
TestBootstrap::test_bootstrap_binary_disabled_resumable_bootstrap checks non-existent log messages for 3.0 and 3.11

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -15,6 +15,8 @@ from ccmlib.node import TimeoutError
 
 import pytest
 
+from distutils.version import LooseVersion
+
 from dtest import Tester, create_ks, create_cf, data_size
 from tools.assertions import (assert_almost_equal, assert_bootstrap_state, assert_not_running,
                               assert_one, assert_stderr_clean)
@@ -334,6 +336,50 @@ class TestBootstrap(Tester):
             else:
                 node3.watch_log_for("Unable to find sufficient sources for streaming range")
             assert_not_running(node3)
+
+    @since('2.2')
+    def test_resumable_bootstrap(self):
+        """
+        Test resuming bootstrap after data streaming failure
+        """
+        cluster = self.cluster
+        cluster.populate(2)
+
+        node1 = cluster.nodes['node1']
+        # set up byteman
+        node1.byteman_port = '8100'
+        node1.import_config_files()
+
+        cluster.start(wait_other_notice=True)
+        # kill stream to node3 in the middle of streaming to let it fail
+        if cluster.version() < '4.0':
+            node1.byteman_submit([self.byteman_submit_path_pre_4_0])
+        else:
+            node1.byteman_submit([self.byteman_submit_path_4_0])
+        node1.stress(['write', 'n=1K', 'no-warmup', 'cl=TWO', '-schema', 'replication(factor=2)', '-rate', 'threads=50'])
+        cluster.flush()
+
+        # start bootstrapping node3 and wait for streaming
+        node3 = new_node(cluster)
+        node3.start(wait_other_notice=False)
+
+        # let streaming fail as we expect
+        node3.watch_log_for('Some data streaming failed')
+
+        # bring back node3 and invoke nodetool bootstrap to resume bootstrapping
+        node3.nodetool('bootstrap resume')
+        node3.wait_for_binary_interface()
+        assert_bootstrap_state(self, node3, 'COMPLETED')
+
+        # cleanup to guarantee each node will only have sstables of its ranges
+        cluster.cleanup()
+
+        logger.debug("Check data is present")
+        # Let's check stream bootstrap completely transferred data
+        stdout, stderr, _ = node3.stress(['read', 'n=1k', 'no-warmup', '-schema', 'replication(factor=2)', '-rate', 'threads=8'])
+
+        if stdout is not None:
+            assert "FAILURE" not in stdout
 
     @since('2.2')
     def test_bootstrap_with_reset_bootstrap_state(self):
@@ -708,13 +754,10 @@ class TestBootstrap(Tester):
         shutil.rmtree(commitlog_dir)
 
     @since('2.2')
-    def test_bootstrap_binary_disabled_resumable_bootstrap(self):
+    def test_bootstrap_binary_disabled(self):
         """
         Test binary while bootstrapping and streaming fails
         @jira_ticket CASSANDRA-14526, CASSANDRA-14525
-        Test resumable bootstrap
-        In very rare cases this test might fail because the bootstrap completes before the streaming failure
-        @jira_ticket CASSANDRA-15614
         """
         config = {'authenticator': 'org.apache.cassandra.auth.PasswordAuthenticator',
                   'authorizer': 'org.apache.cassandra.auth.CassandraAuthorizer',
@@ -746,7 +789,9 @@ class TestBootstrap(Tester):
         node2.import_config_files()
         node2.start(jvm_args=["-Dcassandra.ring_delay_ms=5000"], wait_other_notice=True)
         self.assert_log_had_msg(node2, 'Some data streaming failed')
-        self.assert_log_had_msg(node2, 'Not starting client transports as bootstrap has not completed')
+
+        if self.cluster.version() >= LooseVersion('4.0'):
+            self.assert_log_had_msg(node2, 'Not starting client transports as bootstrap has not completed')
 
         try:
             node2.nodetool('join')


### PR DESCRIPTION
- reintroduced test_resumable_bootstrap, which was supposed to have been removed only temporarily
- fixed test_bootstrap_binary_disabled to avoid checking for log messages that only exist on 4.0+ when testing 3.0 and 3.11

