### PR TITLE
remove redundant params for Cluster.start

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ JAVA7_HOME and JAVA8_HOME, respectively.
 Writing Tests
 -------------
 
-- Most of the time when you start a cluster with `cluster.start()`, you'll want to pass in `wait_for_binary_proto=True` so the call blocks until the cluster is ready to accept CQL connections. We tried setting this to `True` by default once, but the problems caused there (e.g. when it waited the full timeout time on a node that was deliberately down) were more unpleasant and more difficult to debug than the problems caused by having it `False` by default.
 - If you're using JMX via [the `tools.jmxutils` module](tools/jmxutils.py), make sure to call `remove_perf_disable_shared_mem` on the node or nodes you want to query with JMX _before starting the nodes_. `remove_perf_disable_shared_mem` disables a JVM option that's incompatible with JMX (see [this JMX ticket](https://github.com/rhuss/jolokia/issues/198)). It works by performing a string replacement in the node's Cassandra startup script, so changes will only propagate to the node at startup time.
 
 If you'd like to know what to expect during a code review, please see the included [CONTRIBUTING file](CONTRIBUTING.md).

--- a/auditlog_test.py
+++ b/auditlog_test.py
@@ -24,7 +24,7 @@ class TestAuditlog(Tester):
                                                                             'audit_logs_dir': log_dir,
                                                                             'roll_cycle': 'TEST_SECONDLY',
                                                                             'archive_command':'%s %%path'%(move_script)}})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         node.stress(['write', 'n=100k', "no-warmup", "cl=ONE", "-rate", "threads=300"])
         node.nodetool("disableauditlog")
@@ -38,7 +38,7 @@ class TestAuditlog(Tester):
         moved_log_dir, move_script = self._create_script()
         cluster.set_configuration_options(values={'full_query_logging_options': {'log_dir': log_dir,
                                                                                  'archive_command': 'conf should not be used'}})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         node.nodetool("enablefullquerylog --archive-command \"%s %%path\" --roll-cycle=TEST_SECONDLY"%move_script)
         node.stress(['write', 'n=100k', "no-warmup", "cl=ONE", "-rate", "threads=300"])
@@ -58,7 +58,7 @@ class TestAuditlog(Tester):
         cluster.set_configuration_options(values={'full_query_logging_options': {'log_dir': log_dir,
                                                                                  'roll_cycle': 'TEST_SECONDLY',
                                                                                  'archive_command':'%s %%path'%(move_script)}})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         node.nodetool("enablefullquerylog")
         node.stress(['write', 'n=100k', "no-warmup", "cl=ONE", "-rate", "threads=300"])
@@ -87,7 +87,7 @@ class TestAuditlog(Tester):
         cluster.set_configuration_options(values={'full_query_logging_options': {'log_dir': log_dir,
                                                                                  'roll_cycle': 'TEST_SECONDLY',
                                                                                  'archive_command':'%s %%path'%(move_script)}})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         node.nodetool("enablefullquerylog")
 
@@ -104,7 +104,7 @@ class TestAuditlog(Tester):
         cluster.set_configuration_options(values={'full_query_logging_options': {'log_dir': log_dir,
                                                                                  'roll_cycle': 'TEST_SECONDLY',
                                                                                  'archive_command':'%s %%path'%(move_script)}})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         node.nodetool("enablefullquerylog")
 

--- a/auth_join_ring_false_test.py
+++ b/auth_join_ring_false_test.py
@@ -208,7 +208,7 @@ class TestAuth(Tester):
                   'permissions_validity_in_ms': 0,
                   'roles_validity_in_ms': roles_expiry}
         self.cluster.set_configuration_options(values=config)
-        self.cluster.populate(nodes).start(wait_for_binary_proto=True)
+        self.cluster.populate(nodes).start()
 
         self.cluster.wait_for_any_log('Created default superuser', 25)
 

--- a/auth_test.py
+++ b/auth_test.py
@@ -76,7 +76,7 @@ class TestAuth(Tester):
         logger.debug("Stopping cluster..")
         self.cluster.stop()
         logger.debug("Restarting cluster..")
-        self.cluster.start(wait_other_notice=True)
+        self.cluster.start()
 
         # check each node directly
         for i in range(3):
@@ -1026,7 +1026,7 @@ class TestAuth(Tester):
         if self.dtest_config.cassandra_version_from_build >= '4.0':
             config['network_authorizer'] = 'org.apache.cassandra.auth.AllowAllNetworkAuthorizer'
         self.cluster.set_configuration_options(values=config)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         self.cluster.stop()
         config = {'authenticator': 'org.apache.cassandra.auth.PasswordAuthenticator',
@@ -1034,7 +1034,7 @@ class TestAuth(Tester):
         if self.dtest_config.cassandra_version_from_build >= '4.0':
             config['network_authorizer'] = 'org.apache.cassandra.auth.CassandraNetworkAuthorizer'
         self.cluster.set_configuration_options(values=config)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         philip = self.get_session(user='philip', password='strongpass')
         cathy = self.get_session(user='cathy', password='12345')
@@ -1057,7 +1057,7 @@ class TestAuth(Tester):
         cluster.populate(1)
         [node] = cluster.nodelist()
         remove_perf_disable_shared_mem(node)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         with JolokiaAgent(node) as jmx:
             success = jmx.read_attribute(
@@ -1173,7 +1173,7 @@ class TestAuthRoles(Tester):
                 'roles_validity_in_ms': 0,
                 'num_tokens': 1
             })
-        fixture_dtest_setup.cluster.populate(1, debug=True).start(wait_for_binary_proto=True, jvm_args=['-XX:-PerfDisableSharedMem'])
+        fixture_dtest_setup.cluster.populate(1, debug=True).start(jvm_args=['-XX:-PerfDisableSharedMem'])
         nodes = fixture_dtest_setup.cluster.nodelist()
         fixture_dtest_setup.superuser = fixture_dtest_setup.patient_exclusive_cql_connection(nodes[0], user='cassandra', password='cassandra')
 
@@ -2695,7 +2695,7 @@ class TestAuthRoles(Tester):
             config['network_authorizer'] = 'org.apache.cassandra.auth.CassandraNetworkAuthorizer'
 
         self.cluster.set_configuration_options(values=config)
-        self.cluster.populate(nodes).start(wait_for_binary_proto=True)
+        self.cluster.populate(nodes).start()
 
         self.cluster.wait_for_any_log('Created default superuser', 25)
 
@@ -3040,7 +3040,7 @@ class TestNetworkAuth(Tester):
             'network_authorizer': 'org.apache.cassandra.auth.CassandraNetworkAuthorizer',
             'num_tokens': 1
         })
-        fixture_dtest_setup.cluster.populate([1, 1], debug=True).start(wait_for_binary_proto=True, jvm_args=['-XX:-PerfDisableSharedMem'])
+        fixture_dtest_setup.cluster.populate([1, 1], debug=True).start(jvm_args=['-XX:-PerfDisableSharedMem'])
         fixture_dtest_setup.dc1_node, fixture_dtest_setup.dc2_node = fixture_dtest_setup.cluster.nodelist()
         fixture_dtest_setup.superuser = fixture_dtest_setup.patient_exclusive_cql_connection(fixture_dtest_setup.dc1_node, user='cassandra', password='cassandra')
 

--- a/batch_test.py
+++ b/batch_test.py
@@ -442,7 +442,7 @@ class TestBatch(Tester):
         for n in self.cluster.nodelist():
             remove_perf_disable_shared_mem(n)
 
-        self.cluster.start(wait_other_notice=True)
+        self.cluster.start()
 
         node1 = self.cluster.nodelist()[0]
         session = self.patient_cql_connection(node1, protocol_version=protocol_version)

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -75,7 +75,7 @@ class TestBootstrap(Tester):
             logger.debug("starting source node on version {}".format(bootstrap_from_version))
             node1.set_install_dir(version=bootstrap_from_version)
         node1.set_configuration_options(values={'initial_token': tokens[0]})
-        cluster.start(wait_other_notice=True)
+        cluster.start()
 
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)
@@ -177,7 +177,7 @@ class TestBootstrap(Tester):
         node1.byteman_port = '8100'
         node1.import_config_files()
 
-        cluster.start(wait_other_notice=True)
+        cluster.start()
 
         # Create more than one sstable larger than 1MB
         node1.stress(['write', 'n=1K', '-rate', 'threads=8', '-schema',
@@ -208,7 +208,7 @@ class TestBootstrap(Tester):
         cluster = self.cluster
         # Create a two-node cluster
         cluster.populate(2)
-        cluster.start(wait_other_notice=True)
+        cluster.start()
 
         # Bootstrapping a new node
         node3 = new_node(cluster)
@@ -348,7 +348,7 @@ class TestBootstrap(Tester):
         node1.byteman_port = '8100'
         node1.import_config_files()
 
-        cluster.start(wait_other_notice=True)
+        cluster.start()
         # kill stream to node3 in the middle of streaming to let it fail
         if cluster.version() < '4.0':
             node1.byteman_submit([self.byteman_submit_path_pre_4_0])
@@ -384,7 +384,7 @@ class TestBootstrap(Tester):
         """Test bootstrap with resetting bootstrap progress"""
         cluster = self.cluster
         cluster.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
 
         node1 = cluster.nodes['node1']
         node1.stress(['write', 'n=100K', '-schema', 'replication(factor=2)'])
@@ -422,7 +422,7 @@ class TestBootstrap(Tester):
             @jira_ticket CASSANDRA-9022
         """
         cluster = self.cluster
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         (node1, node2) = cluster.nodelist()
 
         node1.stress(['write', 'n=1K', 'no-warmup', '-schema', 'replication(factor=2)',
@@ -515,7 +515,7 @@ class TestBootstrap(Tester):
         """
         cluster = self.cluster
         cluster.populate(3)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         stress_table = 'keyspace1.standard1'
 
@@ -548,7 +548,7 @@ class TestBootstrap(Tester):
         """
         cluster = self.cluster
         cluster.populate(3)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         stress_table = 'keyspace1.standard1'
 
@@ -584,7 +584,7 @@ class TestBootstrap(Tester):
         """
         cluster = self.cluster
         cluster.populate(1)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1 = cluster.nodelist()[0]
         # Add a new node, bootstrap=True ensures that it is not a seed
@@ -627,7 +627,7 @@ class TestBootstrap(Tester):
         cluster = self.cluster
         cluster.populate(1)
         cluster.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         stress_table = 'keyspace1.standard1'
 
@@ -672,7 +672,7 @@ class TestBootstrap(Tester):
                                }]
         })
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1 = cluster.nodelist()[0]
         node2 = cluster.nodelist()[1]
@@ -758,7 +758,7 @@ class TestBootstrap(Tester):
 
         cluster = self.cluster
         cluster.populate(1)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1, = cluster.nodelist()
 
@@ -795,7 +795,7 @@ class TestBootstrap(Tester):
         cluster = self.cluster
         cluster.set_configuration_options(values={'concurrent_compactors': 4})
         cluster.populate(1)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         node1, = cluster.nodelist()
         for x in range(0, 5):
             node1.stress(['write', 'n=100k', 'no-warmup', '-schema', 'compaction(strategy=SizeTieredCompactionStrategy,enabled=false)', 'replication(factor=1)', '-rate', 'threads=10'])
@@ -854,7 +854,7 @@ class TestBootstrap(Tester):
         node1.byteman_port = '8100'
         node1.import_config_files()
 
-        cluster.start(wait_other_notice=True)
+        cluster.start()
         # kill stream to node2 in the middle of streaming to let it fail
         if cluster.version() < '4.0':
             node1.byteman_submit([self.byteman_submit_path_pre_4_0])

--- a/cdc_test.py
+++ b/cdc_test.py
@@ -265,7 +265,7 @@ class TestCDC(Tester):
             configuration_overrides = {}
         self.cluster.populate(1)
         self.cluster.set_configuration_options(dict(config_defaults, **configuration_overrides))
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node = self.cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
         create_ks(session, ks_name, rf=1)

--- a/cfid_test.py
+++ b/cfid_test.py
@@ -14,7 +14,7 @@ class TestCFID(Tester):
         """
         cluster = self.cluster
 
-        cluster.populate(1).start(wait_other_notice=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -33,7 +33,7 @@ class TestCompaction(Tester):
         Insert data, delete a partition of data and check that the requesite rows are tombstoned.
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -70,7 +70,7 @@ class TestCompaction(Tester):
         Insert data and check data size before and after a compaction.
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         stress_write(node1)
@@ -119,7 +119,7 @@ class TestCompaction(Tester):
             min_bf_size = 100000
             max_bf_size = 150000
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         for x in range(0, 5):
@@ -165,7 +165,7 @@ class TestCompaction(Tester):
         """
         self.skip_if_no_major_compaction(strategy)
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)
@@ -203,7 +203,7 @@ class TestCompaction(Tester):
             pytest.skip('Not implemented unless DateTieredCompactionStrategy is used')
 
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)
@@ -245,7 +245,7 @@ class TestCompaction(Tester):
         Set throughput, insert data and ensure compaction performance corresponds.
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         # disableautocompaction only disables compaction for existing tables,
@@ -303,7 +303,7 @@ class TestCompaction(Tester):
         if strategy in strategies:
             strategies.remove(strategy)
             cluster = self.cluster
-            cluster.populate(1).start(wait_for_binary_proto=True)
+            cluster.populate(1).start()
             [node1] = cluster.nodelist()
 
             for strat in strategies:
@@ -331,7 +331,7 @@ class TestCompaction(Tester):
                 node1.flush()
                 cluster.clear()
                 time.sleep(5)
-                cluster.start(wait_for_binary_proto=True)
+                cluster.start()
 
     def test_large_compaction_warning(self):
         """
@@ -340,7 +340,7 @@ class TestCompaction(Tester):
         """
         cluster = self.cluster
         cluster.set_configuration_options({'compaction_large_partition_warning_threshold_mb': 1})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)
@@ -373,7 +373,7 @@ class TestCompaction(Tester):
         Make sure we can enable/disable compaction using nodetool
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -399,7 +399,7 @@ class TestCompaction(Tester):
         Make sure we can disable compaction via the schema compaction parameter 'enabled' = false
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -433,7 +433,7 @@ class TestCompaction(Tester):
         Make sure we can enable compaction using an alter-statement
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -462,7 +462,7 @@ class TestCompaction(Tester):
         Make sure compaction stays disabled after an alter statement where we have disabled using nodetool first
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -498,7 +498,7 @@ class TestCompaction(Tester):
         @jira_ticket CASSANDRA-11765
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         # disableautocompaction only disables compaction for existing tables,
@@ -527,7 +527,7 @@ class TestCompaction(Tester):
             pytest.skip('Not implemented unless LeveledCompactionStrategy is used')
 
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         stress_write(node1, keycount=1)

--- a/compression_test.py
+++ b/compression_test.py
@@ -29,7 +29,7 @@ class TestCompression(TestHelper):
         using new cql create table syntax to disable compression
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)
@@ -59,7 +59,7 @@ class TestCompression(TestHelper):
         using new cql create table syntax to configure compression
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)
@@ -124,7 +124,7 @@ class TestCompression(TestHelper):
         starting with compression enabled then disabling it
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)
@@ -155,7 +155,7 @@ class TestCompression(TestHelper):
         starting with compression disabled and enabling it
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)

--- a/configuration_test.py
+++ b/configuration_test.py
@@ -75,7 +75,7 @@ class TestConfiguration(Tester):
             # disable JVM option so we can use Jolokia
             # this has to happen after .set_configuration_options because of implementation details
             remove_perf_disable_shared_mem(node)
-            self.fixture_dtest_setup.cluster.start(wait_for_binary_proto=True)
+            self.fixture_dtest_setup.cluster.start()
             return node
 
         durable_node = new_commitlog_cluster_node()
@@ -117,7 +117,7 @@ class TestConfiguration(Tester):
         default_path = node1.data_directories()[0]
         node1.set_configuration_options({'saved_caches_directory': os.path.join(default_path, 'saved_caches')})
         remove_perf_disable_shared_mem(node1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         session = self.patient_exclusive_cql_connection(node1)
         session.execute("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}")
@@ -130,7 +130,7 @@ class TestConfiguration(Tester):
             jmx.execute_method(cache_service, 'saveCaches')
 
         self.cluster.stop()
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
     def _check_chunk_length(self, session, value):
         result = session.cluster.metadata.keyspaces['ks'].tables['test_table'].as_cql_query()

--- a/consistency_test.py
+++ b/consistency_test.py
@@ -132,7 +132,7 @@ class TestHelper(Tester):
             cluster.set_configuration_options(values={
                 'endpoint_snitch': 'org.apache.cassandra.locator.PropertyFileSnitch'})
 
-        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.start()
 
         self.ksname = 'mytestks'
         session = self.patient_exclusive_cql_connection(cluster.nodelist()[0])
@@ -784,7 +784,7 @@ class TestConsistency(Tester):
         # set column_index_size_in_kb to 1 for a slightly easier reproduction sequence
         cluster.set_configuration_options(values={'column_index_size_in_kb': 1})
 
-        cluster.populate(1).start(wait_other_notice=True)
+        cluster.populate(1).start()
         node1 = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node1)
@@ -842,7 +842,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'column_index_size_in_kb': 1, 'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(3).start(wait_other_notice=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_exclusive_cql_connection(node1)
@@ -916,7 +916,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node2)
@@ -965,7 +965,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1018,7 +1018,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1081,7 +1081,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1141,7 +1141,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1176,7 +1176,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1232,7 +1232,7 @@ class TestConsistency(Tester):
         cluster.populate(2)
         node1, node2 = cluster.nodelist()
         remove_perf_disable_shared_mem(node1)  # necessary for jmx
-        cluster.start(wait_other_notice=True)
+        cluster.start()
 
         session = self.patient_cql_connection(node1)
 
@@ -1298,7 +1298,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1370,7 +1370,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(3).start(wait_other_notice=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1432,7 +1432,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -1472,7 +1472,7 @@ class TestConsistency(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
 
-        cluster.populate(3).start(wait_other_notice=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)

--- a/consistent_bootstrap_test.py
+++ b/consistent_bootstrap_test.py
@@ -65,7 +65,7 @@ class TestBootstrapConsistency(Tester):
 
         cluster.populate(2)
         node1, node2 = cluster.nodelist()
-        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.start()
 
         logger.debug("Set to talk to node 2")
         n2session = self.patient_cql_connection(node2)

--- a/counter_test.py
+++ b/counter_test.py
@@ -102,7 +102,7 @@ class TestCounters(Tester):
             nodes[0].update_startup_byteman_script('./byteman/4.0/election_counter_leader_favor_node2.btm')
             nodes[2].update_startup_byteman_script('./byteman/4.0/election_counter_leader_favor_node2.btm')
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         session = self.patient_cql_connection(nodes[0])
         create_ks(session, 'ks', 3)
         create_cf(session, 'cf', validation="CounterColumnType", columns={'c': 'counter'})

--- a/cql_test.py
+++ b/cql_test.py
@@ -53,7 +53,7 @@ class CQLTester(Tester):
             cluster.set_configuration_options(values=config)
 
         if not cluster.nodelist():
-            cluster.populate(nodes).start(wait_for_binary_proto=True)
+            cluster.populate(nodes).start()
         node1 = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node1, protocol_version=protocol_version, user=user, password=password)
@@ -803,8 +803,7 @@ class AbortedQueryTester(CQLTester):
         # introduced by CASSANDRA-7392 to pause by the specified amount of milliseconds every
         # CQL row iterated for non system queries, so that these queries take much longer to complete,
         # see ReadCommand.withStateTracking()
-        cluster.populate(1).start(wait_for_binary_proto=True,
-                                  jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
+        cluster.populate(1).start(jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
                                             "-Dcassandra.test.read_iteration_delay_ms=5"])
         node = cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
@@ -919,8 +918,7 @@ class AbortedQueryTester(CQLTester):
                                                   'read_request_timeout_in_ms': 1000,
                                                   'range_request_timeout_in_ms': 1000})
 
-        cluster.populate(1).start(wait_for_binary_proto=True,
-                                  jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
+        cluster.populate(1).start(jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
                                             "-Dcassandra.test.read_iteration_delay_ms=5"])  # see above for explanation
         node = cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
@@ -1034,8 +1032,7 @@ class TestCQLSlowQuery(CQLTester):
         # introduced by CASSANDRA-7392 to pause by the specified amount of milliseconds during each
         # iteration of non system queries, so that these queries take much longer to complete,
         # see ReadCommand.withStateTracking()
-        cluster.populate(1).start(wait_for_binary_proto=True,
-                                  jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
+        cluster.populate(1).start(jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
                                             "-Dcassandra.test.read_iteration_delay_ms=1"])
         node = cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
@@ -1101,8 +1098,7 @@ class TestCQLSlowQuery(CQLTester):
         # introduced by CASSANDRA-7392 to pause by the specified amount of milliseconds during each
         # iteration of non system queries, so that these queries take much longer to complete,
         # see ReadCommand.withStateTracking()
-        cluster.populate(1).start(wait_for_binary_proto=True,
-                                  jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
+        cluster.populate(1).start(jvm_args=["-Dcassandra.monitoring_report_interval_ms=10",
                                             "-Dcassandra.test.read_iteration_delay_ms=1"])
         node = cluster.nodelist()[0]
         session = self.patient_cql_connection(node)
@@ -1397,7 +1393,7 @@ class TestLWTWithCQL(Tester):
     def fixture_post_initialize_cluster(self, fixture_dtest_setup):
         cluster = fixture_dtest_setup.cluster
         cluster.populate(3)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
     def get_lwttester_session(self):
         node1 = self.cluster.nodelist()[0]

--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -38,7 +38,7 @@ class TestCqlTracing(Tester):
         cluster.populate(nodes)
         node1 = cluster.nodelist()[0]
         remove_perf_disable_shared_mem(node1)  # necessary for jmx
-        cluster.start(wait_for_binary_proto=True, jvm_args=jvm_args)
+        cluster.start(jvm_args=jvm_args)
 
         session = self.patient_cql_connection(node1, protocol_version=protocol_version)
         if create_keyspace:

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -149,7 +149,7 @@ class TestCqlsh(Tester, CqlshMixin):
     def test_simple_insert(self):
 
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -176,7 +176,7 @@ class TestCqlsh(Tester, CqlshMixin):
         """
 
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -202,7 +202,7 @@ class TestCqlsh(Tester, CqlshMixin):
     @since('2.2')
     def test_past_and_future_dates(self):
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -232,7 +232,7 @@ class TestCqlsh(Tester, CqlshMixin):
         @jira_ticket 10428
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -382,7 +382,7 @@ class TestCqlsh(Tester, CqlshMixin):
     def test_eat_glass(self):
 
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -505,7 +505,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
     def test_source_glass(self):
 
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -519,7 +519,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
         @jira_ticket CASSANDRA-11626
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -536,7 +536,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
         @jira_ticket CASSANDRA-11626
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -554,7 +554,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
         CASSANDRA-7196. Make sure the server returns empty values and CQLSH prints them properly
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -635,7 +635,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         assert expected in output, "Output \n {0} \n doesn't contain expected\n {1}".format(output, expected)
 
     def test_tracing_from_system_traces(self):
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
 
         node1, = self.cluster.nodelist()
 
@@ -767,7 +767,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
         @jira_ticket CASSANDRA-7814
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
 
         self.execute(
@@ -854,7 +854,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
 
     def test_describe_describes_non_default_compaction_parameters(self):
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node, = self.cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -869,7 +869,7 @@ VALUES (4, blobAsInt(0x), '', blobAsBigint(0x), 0x, blobAsBoolean(0x), blobAsDec
     def test_describe_functions(self, fixture_dtest_setup_overrides):
         """Test DESCRIBE statements for functions and aggregate functions"""
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         create_ks_statement = "CREATE KEYSPACE test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}"
         create_function_statement = """
@@ -941,7 +941,7 @@ CREATE OR REPLACE AGGREGATE test.average(int)
     @since('4.0')
     def test_default_keyspaces_exist(self):
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
 
         # Describe keyspaces
@@ -962,7 +962,7 @@ CREATE OR REPLACE AGGREGATE test.average(int)
     def test_describe_types(self):
         """Test DESCRIBE statements for user defined datatypes"""
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         create_ks_statement = "CREATE KEYSPACE test WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}"
         create_name_type_statement = """
@@ -1003,7 +1003,7 @@ CREATE TYPE test.address_type (
         Test that we can describe tables whose name is a non-reserved CQL keyword
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node, = self.cluster.nodelist()
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -1020,7 +1020,7 @@ CREATE TYPE test.address_type (
         """
         self.cluster.set_configuration_options({'enable_materialized_views': 'true'})
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         self.execute(
             cql="""
@@ -1451,7 +1451,7 @@ CREATE TYPE test.address_type (
     def test_float_formatting(self):
         """ Tests for CASSANDRA-9224, check format of float and double values"""
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1629,7 +1629,7 @@ CREATE TYPE test.address_type (
     def test_int_values(self):
         """ Tests for CASSANDRA-9399, check tables with int, bigint, smallint and tinyint values"""
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1666,7 +1666,7 @@ CREATE TABLE int_checks.values (
     def test_datetime_values(self):
         """ Tests for CASSANDRA-9399, check tables with date and time values"""
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1712,7 +1712,7 @@ CREATE TABLE datetime_checks.values (
     @since('4.0')
     def test_datetime_values_40(self):
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1759,7 +1759,7 @@ CREATE TABLE datetime_checks.values (
         therefore make this test too brittle.
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1806,7 +1806,7 @@ Tracing session:""")
         self.cluster.set_configuration_options({
             'unlogged_batch_across_partitions_warn_threshold': str(max_partitions_per_batch)})
 
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1 = self.cluster.nodelist()[0]
 
@@ -1847,7 +1847,7 @@ Tracing session:""")
         @jira_ticket CASSANDRA-9601
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
 
@@ -1860,7 +1860,7 @@ Tracing session:""")
         @jira_ticket CASSANDRA-15193
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
         stdout, stderr = self.run_cqlsh(node1, cmds='USE system', cqlsh_options=['--tty'])
@@ -1876,7 +1876,7 @@ Tracing session:""")
         """
         self.cluster.populate(1)
         self.cluster.set_configuration_options({ 'native_transport_max_negotiable_protocol_version': str(3)})
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
 
         node1, = self.cluster.nodelist()
         stdout, stderr = self.run_cqlsh(node1, cmds='USE system', cqlsh_options=['--tty'])
@@ -1890,14 +1890,13 @@ Tracing session:""")
         if node1.get_cassandra_version() < '4.0':
             assert "ProtocolError returned from server while using explicitly set client protocol_version 4" in stderr
 
-
     def test_update_schema_with_down_node(self):
         """
         Test that issuing a DML statement after a DDL statement will work with a down node
         @jira_ticket CASSANDRA-9689
         """
         self.cluster.populate(3)
-        self.cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.start()
 
         node1, node2, node3 = self.cluster.nodelist()
         node2.stop(wait_other_notice=True)
@@ -1930,7 +1929,7 @@ Tracing session:""")
         indicates the output of DESCRIBE is not a correct CREATE TABLE statement.
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
 
@@ -1960,7 +1959,7 @@ Tracing session:""")
         """
         self.cluster.set_configuration_options({'enable_materialized_views': 'true'})
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
 
@@ -2042,7 +2041,7 @@ Tracing session:""")
             expression.
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
 
         out, err = self.run_cqlsh(node1, cmd, env_vars={'TERM': 'xterm'})
@@ -2058,7 +2057,7 @@ Tracing session:""")
         @jira_ticket CASSANDRA-10272
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
 
         stdout, stderr = self.run_cqlsh(node1, cmds="""
@@ -2076,7 +2075,7 @@ Tracing session:""")
         @jira_ticket CASSANDRA-15660
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
 
@@ -2096,7 +2095,7 @@ Tracing session:""")
         @jira_ticket CASSANDRA-15905
         """
         self.cluster.populate(1)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         node1, = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
 
@@ -2125,7 +2124,7 @@ class TestCqlshSmoke(Tester, CqlshMixin):
 
     @pytest.fixture(scope='function', autouse=True)
     def fixture_cluster_setup(self, fixture_dtest_setup):
-        fixture_dtest_setup.cluster.populate(1).start(wait_for_binary_proto=True)
+        fixture_dtest_setup.cluster.populate(1).start()
         [self.node1] = fixture_dtest_setup.cluster.nodelist()
         self.session = fixture_dtest_setup.patient_cql_connection(self.node1)
 
@@ -2429,7 +2428,7 @@ class TestCqlLogin(Tester, CqlshMixin):
         cluster = fixture_dtest_setup.cluster
         config = {'authenticator': 'org.apache.cassandra.auth.PasswordAuthenticator'}
         cluster.set_configuration_options(values=config)
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [self.node1] = cluster.nodelist()
         self.node1.watch_log_for('Created default superuser')
         self.session = fixture_dtest_setup.patient_cql_connection(self.node1, user='cassandra', password='cassandra')
@@ -2545,7 +2544,7 @@ class TestCqlshUnicode(Tester, CqlshMixin):
     @pytest.fixture(scope='function', autouse=True)
     def fixture_cluster_setup(self, fixture_dtest_setup):
         cluster = fixture_dtest_setup.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [self.node1] = cluster.nodelist()
         self.session = fixture_dtest_setup.patient_cql_connection(self.node1)
 

--- a/cqlsh_tests/test_cqlsh_copy.py
+++ b/cqlsh_tests/test_cqlsh_copy.py
@@ -101,7 +101,7 @@ class TestCqlshCopy(Tester):
 
             if configuration_options:
                 self.cluster.set_configuration_options(values=configuration_options)
-            self.cluster.populate(nodes, tokens=tokens).start(wait_for_binary_proto=True)
+            self.cluster.populate(nodes, tokens=tokens).start()
         else:
             assert self.cluster.partitioner == p, "Cannot reuse cluster: different partitioner"
             assert len(self.cluster.nodelist()) == nodes, "Cannot reuse cluster: different number of nodes"

--- a/delete_insert_test.py
+++ b/delete_insert_test.py
@@ -39,7 +39,7 @@ class TestDeleteInsert(Tester):
 
     def test_delete_insert_search(self):
         cluster = self.cluster
-        cluster.populate([2, 2]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 2]).start()
         node1 = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node1)

--- a/deletion_test.py
+++ b/deletion_test.py
@@ -51,7 +51,7 @@ class TestDeletion(Tester):
 
         remove_perf_disable_shared_mem(node1)
 
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         [node1] = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)

--- a/disk_balance_test.py
+++ b/disk_balance_test.py
@@ -37,7 +37,7 @@ class TestDiskBalance(Tester):
         cluster = self.cluster
         if self.dtest_config.use_vnodes:
             cluster.set_configuration_options(values={'num_tokens': 256})
-        cluster.populate(4).start(wait_for_binary_proto=True)
+        cluster.populate(4).start()
         node1 = cluster.nodes['node1']
 
         node1.stress(['write', 'n=50k', 'no-warmup', '-rate', 'threads=100', '-schema', 'replication(factor=3)',
@@ -54,7 +54,7 @@ class TestDiskBalance(Tester):
             cluster.set_configuration_options(values={'num_tokens': 256})
         # apparently we have legitimate errors in the log when bootstrapping (see bootstrap_test.py)
         self.fixture_dtest_setup.allow_log_errors = True
-        cluster.populate(4).start(wait_for_binary_proto=True)
+        cluster.populate(4).start()
         node1 = cluster.nodes['node1']
 
         node1.stress(['write', 'n=50k', 'no-warmup', '-rate', 'threads=100', '-schema', 'replication(factor=3)',
@@ -77,7 +77,7 @@ class TestDiskBalance(Tester):
             cluster.set_configuration_options(values={'num_tokens': 256})
         # apparently we have legitimate errors in the log when bootstrapping (see bootstrap_test.py)
         self.fixture_dtest_setup.allow_log_errors = True
-        cluster.populate(4).start(wait_for_binary_proto=True)
+        cluster.populate(4).start()
         node1 = cluster.nodes['node1']
 
         logger.debug("Populating")
@@ -107,7 +107,7 @@ class TestDiskBalance(Tester):
         cluster = self.cluster
         if self.dtest_config.use_vnodes:
             cluster.set_configuration_options(values={'num_tokens': 256})
-        cluster.populate(4).start(wait_for_binary_proto=True)
+        cluster.populate(4).start()
         node1 = cluster.nodes['node1']
         node4 = cluster.nodes['node4']
         node1.stress(['write', 'n=50k', 'no-warmup', '-rate', 'threads=100', '-schema', 'replication(factor=2)',
@@ -128,7 +128,7 @@ class TestDiskBalance(Tester):
         cluster.populate(1)
         [node] = cluster.nodelist()
         remove_perf_disable_shared_mem(node)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         session = self.patient_cql_connection(node)
         create_ks(session, 'ks', 1)
@@ -155,7 +155,7 @@ class TestDiskBalance(Tester):
         cluster = self.cluster
         if self.dtest_config.use_vnodes:
             cluster.set_configuration_options(values={'num_tokens': 256})
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1 = cluster.nodes['node1']
         node1.stress(['write', 'n=1', 'no-warmup', '-rate', 'threads=100', '-schema', 'replication(factor=1)'])
         cluster.flush()
@@ -208,7 +208,7 @@ class TestDiskBalance(Tester):
         cluster.set_configuration_options(values={'concurrent_compactors': num_disks})
 
         logger.debug("Starting node1 with {} data dirs and concurrent_compactors".format(num_disks))
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -281,7 +281,7 @@ class TestDiskBalance(Tester):
         cluster.set_configuration_options(values={'concurrent_compactors': num_disks})
 
         logger.debug("Starting 3 nodes with {} data dirs and concurrent_compactors".format(num_disks))
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1 = cluster.nodelist()[0]
 
         num_flushes = 10

--- a/fqltool_test.py
+++ b/fqltool_test.py
@@ -23,7 +23,7 @@ class TestFQLTool(Tester):
         query log, then makes sure that the data is correct.
         @jira_ticket CASSANDRA-14690
         """
-        self.cluster.populate(2).start(wait_for_binary_proto=True)
+        self.cluster.populate(2).start()
         node1, node2 = self.cluster.nodelist()
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -61,7 +61,7 @@ class TestFQLTool(Tester):
         sure that the results match
         @jira_ticket CASSANDRA-14690
         """
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
         node1 = self.cluster.nodelist()[0]
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -87,7 +87,7 @@ class TestFQLTool(Tester):
         then asserts that the replays of each generates a mismatch
         @jira_ticket CASSANDRA-14690
         """
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
         node1 = self.cluster.nodelist()[0]
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -181,7 +181,7 @@ class TestHintedHandoff(Tester):
 
     @pytest.mark.no_vnodes
     def test_hintedhandoff_decom(self):
-        self.cluster.populate(4).start(wait_for_binary_proto=True)
+        self.cluster.populate(4).start()
         [node1, node2, node3, node4] = self.cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 2)

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -34,7 +34,7 @@ class TestJMX(Tester):
         """
         #
         cluster = self.cluster
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         node1.stress(['write', 'n=500K', 'no-warmup', '-schema', 'replication(factor=3)'])
@@ -73,7 +73,7 @@ class TestJMX(Tester):
         cluster.populate(3)
         node1, node2, node3 = cluster.nodelist()
         remove_perf_disable_shared_mem(node1)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         version = cluster.version()
         node1.stress(['write', 'n=10K', 'no-warmup', '-schema', 'replication(factor=3)'])
@@ -114,7 +114,7 @@ class TestJMX(Tester):
         cluster.populate(1)
         node = cluster.nodelist()[0]
         remove_perf_disable_shared_mem(node)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node.run_cqlsh(cmds="""
             CREATE KEYSPACE mvtest WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 1 };
@@ -188,7 +188,7 @@ class TestJMX(Tester):
         cluster.populate(1)
         node = cluster.nodelist()[0]
         remove_perf_disable_shared_mem(node)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         # Run a quick stress command to create the keyspace and table
         node.stress(['write', 'n=1', 'no-warmup'])
@@ -248,7 +248,7 @@ class TestJMX(Tester):
         @jira_ticket CASSANDRA-9526
         """
         cluster = self.cluster
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         stdout = node1.nodetool("failuredetector").stdout

--- a/legacy_sstables_test.py
+++ b/legacy_sstables_test.py
@@ -28,7 +28,7 @@ class TestLegacySSTables(Tester):
         # start with 2.1.20 to generate a legacy sstable
         cluster.set_install_dir(version='2.1.20')
 
-        cluster.populate(1).start(wait_other_notice=True)
+        cluster.populate(1).start()
         node1 = cluster.nodelist()[0]
         session = self.patient_cql_connection(node1)
 

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -1118,7 +1118,7 @@ class TestMaterializedViews(Tester):
             node.mark_log(filename='debug.log')
 
         logger.debug("Restart the cluster")
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         session = self.patient_cql_connection(node1)
         session.execute("USE ks")
 
@@ -1292,7 +1292,7 @@ class TestMaterializedViews(Tester):
         logger.debug("Restart the cluster")
         self.cluster.stop()
         marks = [node.mark_log() for node in nodes]
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         session = self.patient_cql_connection(nodes[0])
 
         logger.debug("Verify that the MV has been successfully created")
@@ -2884,7 +2884,7 @@ class TestMaterializedViewsLockcontention(Tester):
         for node in self.nodes:
             remove_perf_disable_shared_mem(node)
 
-        self.cluster.start(wait_for_binary_proto=True, jvm_args=[
+        self.cluster.start(jvm_args=[
             "-Dcassandra.test.fail_mv_locks_count=64"
         ])
 

--- a/metadata_test.py
+++ b/metadata_test.py
@@ -38,7 +38,7 @@ class TestMetadata(Tester):
         self.fixture_dtest_setup.ignore_log_patterns = ['.*Unknown keyspace/cf pair.*']
 
         cluster = self.cluster
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         (node1, node2) = cluster.nodelist()
 
         node1.nodetool("disableautocompaction")

--- a/nodetool_test.py
+++ b/nodetool_test.py
@@ -54,7 +54,7 @@ class TestNodetool(Tester):
                 for line in ["dc={}".format(node.data_center), "rack=rack{}".format(i % 2)]:
                     snitch_file.write(line + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         for i, node in enumerate(cluster.nodelist()):
             out, err, _ = node.nodetool('info')
@@ -120,7 +120,7 @@ class TestNodetool(Tester):
         @jira_ticket CASSANDRA-13526
         Test nodetool cleanup KS to remove old data when new replicas in current node instead of directly returning success.
         """
-        self.cluster.populate([1, 1]).start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.populate([1, 1]).start()
 
         node_dc1 = self.cluster.nodelist()[0]
         node_dc2 = self.cluster.nodelist()[1]
@@ -360,7 +360,7 @@ class TestNodetool(Tester):
         @expected_result This test invokes nodetool describecluster and matches the output with the expected one
         """
         cluster = self.cluster
-        cluster.populate([1, 2, 1]).start(wait_for_binary_proto=True)
+        cluster.populate([1, 2, 1]).start()
 
         node1_dc1, node1_dc2, node2_dc2, node1_dc3 = cluster.nodelist()
 

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -34,7 +34,7 @@ class TestOfflineTools(Tester):
         @jira_ticket CASSANDRA-7614
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node1 = cluster.nodelist()[0]
 
         # test by trying to run on nonexistent keyspace
@@ -47,7 +47,7 @@ class TestOfflineTools(Tester):
             assert e.exit_status == 1, "Expected sstablelevelreset to have a return code of 1 == but instead return code was {}".format(e.exit_status)
 
         # now test by generating keyspace but not flushing sstables
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         node1.stress(['write', 'n=100', 'no-warmup', '-schema', 'replication(factor=1)',
                       '-rate', 'threads=8'])
         cluster.stop(gently=False)
@@ -58,7 +58,7 @@ class TestOfflineTools(Tester):
         assert rc == 0, str(rc)
 
         # test by writing small amount of data and flushing (all sstables should be level 0)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         session = self.patient_cql_connection(node1)
         session.execute("ALTER TABLE keyspace1.standard1 with compaction={'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb':1};")
         node1.stress(['write', 'n=1K', 'no-warmup', '-schema', 'replication(factor=1)',
@@ -72,7 +72,7 @@ class TestOfflineTools(Tester):
         assert rc == 0, str(rc)
 
         # test by loading large amount data so we have multiple levels and checking all levels are 0 at end
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         node1.stress(['write', 'n=50K', 'no-warmup', '-schema', 'replication(factor=1)',
                       '-rate', 'threads=8'])
         cluster.flush()
@@ -116,7 +116,7 @@ class TestOfflineTools(Tester):
         """
         cluster = self.cluster
         cluster.set_configuration_options(values={'compaction_throughput_mb_per_sec': 0})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node1 = cluster.nodelist()[0]
 
         # NOTE - As of now this does not return when it encounters Exception and causes test to hang, temporarily commented out
@@ -143,7 +143,7 @@ class TestOfflineTools(Tester):
             assert e.exit_status == 1, str(e.exit_status)
 
         # test by flushing (sstable should be level 0)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         session = self.patient_cql_connection(node1)
         logger.debug("Altering compaction strategy to LCS")
         session.execute("ALTER TABLE keyspace1.standard1 with compaction={'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb':1, 'enabled':'false'};")
@@ -160,7 +160,7 @@ class TestOfflineTools(Tester):
         assert re.search("L0=1", output)
         assert rc == 0, str(rc)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         node1.nodetool('enableautocompaction keyspace1 standard1')
         # test by loading large amount data so we have multiple sstables
         # must write enough to create more than just L1 sstables
@@ -221,7 +221,7 @@ class TestOfflineTools(Tester):
         Test on potential situations: deleted sstables, corrupted sstables
         """
         cluster = self.cluster
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         # test on nonexistent keyspace
@@ -298,7 +298,7 @@ class TestOfflineTools(Tester):
 
     def test_sstableexpiredblockers(self):
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)
@@ -351,7 +351,7 @@ class TestOfflineTools(Tester):
             cluster.set_install_dir(version='github:apache/cassandra-3.0')
 
         # Start up last major version, write out an sstable to upgrade, and stop node
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
         # Check that node1 is actually what we expect
         logger.debug('Downgraded install dir: {}'.format(node1.get_install_dir()))
@@ -368,7 +368,7 @@ class TestOfflineTools(Tester):
         # Check that node1 is actually upgraded
         logger.debug('Upgraded to original install dir: {}'.format(node1.get_install_dir()))
         # Perform a node start/stop so system tables get internally updated, otherwise we may get "Unknown keyspace/table ks.cf"
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
         node1.flush()
         cluster.stop()
 
@@ -402,7 +402,7 @@ class TestOfflineTools(Tester):
         cluster = self.cluster
         # disable JBOD conf since the test expects exactly one SSTable to be written.
         cluster.set_datadir_count(1)
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node1] = cluster.nodelist()
         session = self.patient_cql_connection(node1)
         create_ks(session, 'ks', 1)

--- a/paging_test.py
+++ b/paging_test.py
@@ -30,7 +30,7 @@ class BasePagingTester(Tester):
         supports_v5 = self.supports_v5_protocol(self.cluster.version())
         protocol_version = 5 if supports_v5 else None
         cluster = self.cluster
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1 = cluster.nodelist()[0]
         session = self.patient_cql_connection(node1,
                                               protocol_version=protocol_version,

--- a/paxos_test.py
+++ b/paxos_test.py
@@ -53,10 +53,10 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[1].stop()
         assert_unavailable(session.execute, "INSERT INTO test (k, v) VALUES (2, 2) IF NOT EXISTS")
 
-        self.cluster.nodelist()[1].start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.nodelist()[1].start()
         session.execute("INSERT INTO test (k, v) VALUES (3, 3) IF NOT EXISTS")
 
-        self.cluster.nodelist()[2].start(wait_for_binary_proto=True)
+        self.cluster.nodelist()[2].start()
         session.execute("INSERT INTO test (k, v) VALUES (4, 4) IF NOT EXISTS")
 
     @pytest.mark.no_vnodes
@@ -75,10 +75,10 @@ class TestPaxos(Tester):
         self.cluster.nodelist()[1].stop()
         session.execute("INSERT INTO test (k, v) VALUES (3, 2) IF NOT EXISTS")
 
-        self.cluster.nodelist()[1].start(wait_for_binary_proto=True)
+        self.cluster.nodelist()[1].start()
         session.execute("INSERT INTO test (k, v) VALUES (5, 5) IF NOT EXISTS")
 
-        self.cluster.nodelist()[2].start(wait_for_binary_proto=True)
+        self.cluster.nodelist()[2].start()
         session.execute("INSERT INTO test (k, v) VALUES (6, 6) IF NOT EXISTS")
 
     def test_contention_multi_iterations(self):

--- a/pending_range_test.py
+++ b/pending_range_test.py
@@ -23,7 +23,7 @@ class TestPendingRangeMovements(Tester):
             cluster.set_log_level('DEBUG')
 
         # Create 5 node cluster
-        cluster.populate(5).start(wait_for_binary_proto=True)
+        cluster.populate(5).start()
         node1, node2 = cluster.nodelist()[0:2]
 
         # Set up RF=3 keyspace

--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -93,7 +93,7 @@ class TestPushedNotifications(Tester):
         @jira_ticket CASSANDRA-8516
         Moving a token should result in MOVED_NODE notifications.
         """
-        self.cluster.populate(3).start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.populate(3).start()
 
         waiters = [NotificationWaiter(self, node, ["TOPOLOGY_CHANGE"])
                    for node in list(self.cluster.nodes.values())]
@@ -136,7 +136,7 @@ class TestPushedNotifications(Tester):
 
         self.change_rpc_address_to_localhost()
 
-        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.start()
 
         waiters = [NotificationWaiter(self, node, ["TOPOLOGY_CHANGE"])
                    for node in list(self.cluster.nodes.values())]
@@ -173,7 +173,7 @@ class TestPushedNotifications(Tester):
         @jira_ticket CASSANDRA-7816
         Restarting a node should generate exactly one DOWN and one UP notification
         """
-        self.cluster.populate(2).start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.populate(2).start()
         node1, node2 = self.cluster.nodelist()
 
         waiter = NotificationWaiter(self, node1, ["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
@@ -223,7 +223,7 @@ class TestPushedNotifications(Tester):
 
         self.change_rpc_address_to_localhost()
 
-        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.start()
 
         # register for notification with node1
         waiter = NotificationWaiter(self, node1, ["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
@@ -260,7 +260,7 @@ class TestPushedNotifications(Tester):
         Test that NEW_NODE and REMOVED_NODE are sent correctly as nodes join and leave.
         @jira_ticket CASSANDRA-11038
         """
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
         node1 = self.cluster.nodelist()[0]
 
         waiter = NotificationWaiter(self, node1, ["STATUS_CHANGE", "TOPOLOGY_CHANGE"])
@@ -325,7 +325,7 @@ class TestPushedNotifications(Tester):
         will generate the correct schema change notifications.
         """
         self.cluster.set_configuration_options({'enable_materialized_views': 'true'})
-        self.cluster.populate(2).start(wait_for_binary_proto=True)
+        self.cluster.populate(2).start()
         node1, node2 = self.cluster.nodelist()
 
         session = self.patient_cql_connection(node1)

--- a/read_failures_test.py
+++ b/read_failures_test.py
@@ -37,7 +37,7 @@ class TestReadFailures(Tester):
             values={'tombstone_failure_threshold': self.tombstone_failure_threshold}
         )
         self.cluster.populate(3)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         self.nodes = list(self.cluster.nodes.values())
 
         session = self.patient_exclusive_cql_connection(self.nodes[0], protocol_version=self.protocol_version)

--- a/read_repair_test.py
+++ b/read_repair_test.py
@@ -98,7 +98,7 @@ class TestReadRepair(Tester):
                 snitch_file.write("rack=rack1" + os.linesep)
                 snitch_file.write("prefer_local=true" + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
     @since('3.0')
     def test_alter_rf_and_run_read_repair(self):
@@ -302,7 +302,7 @@ class TestReadRepair(Tester):
 
         self.cluster.flush()
         self.cluster.stop()
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         session1 = self.patient_exclusive_cql_connection(node1)
 
         for n in range(1, 1000):
@@ -444,7 +444,7 @@ class TestSpeculativeReadRepair(Tester):
                                                   'read_request_timeout_in_ms': 1000})
         cluster.populate(3, install_byteman=True, debug=True)
         byteman_validate(cluster.nodelist()[0], './byteman/read_repair/sorted_live_endpoints.btm', verbose=True)
-        cluster.start(wait_for_binary_proto=True, jvm_args=['-XX:-PerfDisableSharedMem'])
+        cluster.start(jvm_args=['-XX:-PerfDisableSharedMem'])
         session = fixture_dtest_setup.patient_exclusive_cql_connection(cluster.nodelist()[0], timeout=2)
 
         session.execute("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
@@ -744,8 +744,7 @@ class TestReadRepairGuarantees(Tester):
                                                   'dynamic_snitch': False,
                                                   'write_request_timeout_in_ms': 500,
                                                   'read_request_timeout_in_ms': 500})
-        cluster.populate(3, install_byteman=True, debug=True).start(wait_for_binary_proto=True,
-                                                                    jvm_args=['-XX:-PerfDisableSharedMem'])
+        cluster.populate(3, install_byteman=True, debug=True).start(jvm_args=['-XX:-PerfDisableSharedMem'])
         session = fixture_dtest_setup.patient_exclusive_cql_connection(cluster.nodelist()[0], timeout=2)
 
         session.execute("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -331,7 +331,7 @@ class TestRebuild(Tester):
         node1.set_configuration_options(values={'initial_token': node1_token})
         node2.set_configuration_options(values={'initial_token': node2_token})
         node3.set_configuration_options(values={'initial_token': node3_token})
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         session = self.patient_exclusive_cql_connection(node1)
         session.execute("CREATE KEYSPACE ks1 WITH replication = {'class':'SimpleStrategy', 'replication_factor':2};")
@@ -365,7 +365,7 @@ class TestRebuild(Tester):
         node1.set_configuration_options(values={'initial_token': node1_token})
         node2.set_configuration_options(values={'initial_token': node2_token})
         node3.set_configuration_options(values={'initial_token': node3_token})
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node3_address = node3.network_interfaces['binary'][0]
 
@@ -401,7 +401,7 @@ class TestRebuild(Tester):
         cluster.populate([1, 1], tokens=tokens[:2])
         node1, node2 = cluster.nodelist()
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         # populate data in dc1, dc2
         session = self.patient_exclusive_cql_connection(node1)

--- a/refresh_test.py
+++ b/refresh_test.py
@@ -14,7 +14,7 @@ class TestRefresh(Tester):
         node = self.cluster.nodelist()[0]
         node.byteman_port = '8100'
         node.import_config_files()
-        self.cluster.start(wait_other_notice=True)
+        self.cluster.start()
         session = self.patient_cql_connection(node)
         session.execute("CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}")
         session.execute("CREATE TABLE ks.a (id int primary key, d text)")

--- a/repair_tests/deprecated_repair_test.py
+++ b/repair_tests/deprecated_repair_test.py
@@ -228,7 +228,7 @@ class TestDeprecatedRepairNotifications(Tester):
         cluster = self.cluster
         cluster.populate(2)
         node1, node2 = cluster.nodelist()
-        cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.start()
 
         # write some data that could be repaired
         logger.debug("Stressing node1...")

--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -578,7 +578,7 @@ class TestIncRepair(Tester):
         @jira_ticket CASSANDRA-11172 - repeated full repairs should not cause infinite loop in getNextBackgroundTask
         """
         cluster = self.cluster
-        cluster.populate(2).start(wait_for_binary_proto=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
         for x in range(0, 10):
             node1.stress(['write', 'n=100k', 'no-warmup', '-rate', 'threads=10', '-schema', 'compaction(strategy=LeveledCompactionStrategy,sstable_size_in_mb=10)', 'replication(factor=2)'])
@@ -663,7 +663,7 @@ class TestIncRepair(Tester):
         * Assert no extra, unrepaired sstables are generated
         """
         cluster = self.cluster
-        cluster.populate(4).start(wait_for_binary_proto=True)
+        cluster.populate(4).start()
         node1, node2, node3, node4 = cluster.nodelist()
 
         logger.debug("Inserting data with stress")

--- a/repair_tests/repair_test.py
+++ b/repair_tests/repair_test.py
@@ -95,7 +95,7 @@ class BaseRepairTest(Tester):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True, wait_other_notice=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1, retry_policy=FlakyRetryPolicy(max_retries=15))
@@ -172,7 +172,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         logger.debug("Starting cluster..")
-        cluster.populate([2, 2]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 2]).start()
         node1_1, node2_1, node1_2, node2_2 = cluster.nodelist()
         node1_1.stress(stress_options=['write', 'n=50K', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=4)', '-rate', 'threads=50'])
         node1_1.nodetool("repair -local keyspace1 standard1")
@@ -197,7 +197,7 @@ class TestRepair(BaseRepairTest):
         self.fixture_dtest_setup.ignore_log_patterns = [r'Unknown keyspace/cf pair']
         cluster = self.cluster
         logger.debug('Starting nodes')
-        cluster.populate(2).start(wait_for_binary_proto=True)
+        cluster.populate(2).start()
         node1, _ = cluster.nodelist()
         logger.debug('Creating keyspace and tables')
         node1.stress(stress_options=['write', 'n=1', 'no-warmup',
@@ -241,7 +241,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         logger.debug("Starting cluster..")
-        cluster.populate([2, 2]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 2]).start()
         node1_1, node2_1, node1_2, node2_2 = cluster.nodelist()
         node1_1.stress(stress_options=['write', 'n=100K', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=4)', '-rate', 'threads=50'])
         node1_1.nodetool("repair -hosts 127.0.0.1,127.0.0.2,127.0.0.3,127.0.0.4 keyspace1 standard1")
@@ -262,7 +262,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
         node1.stress(stress_options=['write', 'n=50K', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=3)', '-rate', 'threads=50'])
         node1.nodetool("repair -st 0 -et 1000 keyspace1 standard1")
@@ -304,7 +304,7 @@ class TestRepair(BaseRepairTest):
         logger.debug("Starting cluster..")
         # disable JBOD conf since the test expects sstables to be on the same disk
         cluster.set_datadir_count(1)
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
         # we use RF to make sure to cover only a set of sub-ranges when doing -full -pr
         node1.stress(stress_options=['write', 'n=50K', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=2)', '-rate', 'threads=50'])
@@ -337,7 +337,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         logger.debug("Starting cluster..")
-        cluster.populate([2, 2]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 2]).start()
         node1_1, node2_1, node1_2, node2_2 = cluster.nodelist()
         node1_1.stress(stress_options=['write', 'n=50K', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=4)'])
         node1_1.nodetool("repair keyspace1 standard1")
@@ -709,7 +709,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
         # populate 2 nodes in dc1, and one node each in dc2 and dc3
-        cluster.populate([2, 1, 1]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 1, 1]).start()
 
         node1, node2, node3, node4 = cluster.nodelist()
         session = self.patient_cql_connection(node1)
@@ -758,7 +758,7 @@ class TestRepair(BaseRepairTest):
 
         cluster = self.cluster
         logger.debug("Starting cluster..")
-        cluster.populate([3]).start(wait_for_binary_proto=True)
+        cluster.populate([3]).start()
         node1, node2, node3 = cluster.nodelist()
         node1.stress(stress_options=['write', 'n=10k', 'no-warmup', 'cl=ONE', '-schema', 'replication(factor=3)', '-rate', 'threads=50'])
 
@@ -795,7 +795,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -819,7 +819,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -868,7 +868,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -892,7 +892,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -966,7 +966,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -1009,7 +1009,7 @@ class TestRepair(BaseRepairTest):
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
         cluster.set_batch_commitlog(enabled=True)
         logger.debug("Starting cluster..")
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
 
         node1, node2, node3 = cluster.nodelist()
 
@@ -1050,7 +1050,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
         node2.stop(wait_other_notice=True)
         node1.stress(['write', 'n=1M', 'no-warmup', '-schema', 'replication(factor=3)', '-rate', 'threads=30'])
@@ -1077,7 +1077,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
-        cluster.populate(2).start(wait_for_binary_proto=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
         node2.stop(wait_other_notice=True)
         profile_path = os.path.join(os.getcwd(), 'stress_profiles/repair_wide_rows.yaml')
@@ -1095,7 +1095,7 @@ class TestRepair(BaseRepairTest):
         """
         cluster = self.cluster
         cluster.set_configuration_options(values={'hinted_handoff_enabled': False})
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
         node1.stress(['write', 'n=100k', '-schema', 'replication(factor=3)', '-rate', 'threads=30'])
 
@@ -1193,8 +1193,8 @@ class TestRepair(BaseRepairTest):
         node_to_kill.import_config_files()
 
         logger.debug("Starting cluster..")
-        cluster.start(wait_other_notice=True, jvm_args=['-Djdk.attach.allowAttachSelf=true'])
-        # cluster.start(wait_other_notice=True)
+        cluster.start(jvm_args=['-Djdk.attach.allowAttachSelf=true'])
+        # cluster.start()
 
         logger.debug("stopping node3")
         node3.stop(gently=False, wait_other_notice=True)
@@ -1276,7 +1276,7 @@ class TestRepairDataSystemTable(Tester):
         a 5-node cluster, then inserting 5000 values with RF=3.
         """
         self.cluster = fixture_dtest_setup.cluster
-        self.cluster.populate(5).start(wait_for_binary_proto=True)
+        self.cluster.populate(5).start()
         self.node1 = self.cluster.nodelist()[0]
         self.session = fixture_dtest_setup.patient_cql_connection(self.node1)
 

--- a/replication_test.py
+++ b/replication_test.py
@@ -204,7 +204,7 @@ class TestReplication(Tester):
         """
         Test the SimpleStrategy on a 3 node cluster
         """
-        self.cluster.populate(3).start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.populate(3).start()
         node1 = self.cluster.nodelist()[0]
         session = self.patient_exclusive_cql_connection(node1, consistency_level=ConsistencyLevel.ALL)
         session.max_trace_wait = 120
@@ -240,7 +240,7 @@ class TestReplication(Tester):
         """
         Test the NetworkTopologyStrategy on a 2DC 3:3 node cluster
         """
-        self.cluster.populate([3, 3]).start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.cluster.populate([3, 3]).start()
 
         node1 = self.cluster.nodelist()[0]
         ip_nodes = dict((node.address(), node) for node in self.cluster.nodelist())
@@ -541,7 +541,7 @@ class TestSnitchConfigurationUpdate(Tester):
                 for line in snitch_lines_before(i, node):
                     topo_file.write(line + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         session = self.patient_cql_connection(cluster.nodelist()[0])
 
@@ -697,7 +697,7 @@ class TestSnitchConfigurationUpdate(Tester):
                 for line in snitch_lines_before:
                     topo_file.write(line + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         # check racks are as specified
         self.wait_for_nodes_on_racks(cluster.nodelist(), racks)
@@ -742,7 +742,7 @@ class TestSnitchConfigurationUpdate(Tester):
             topo_file.write("dc=dc9" + os.linesep)
             topo_file.write("rack=rack1" + os.linesep)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node.stop()
 

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -333,7 +333,7 @@ class TestSecondaryIndexes(Tester):
         """
 
         cluster = self.cluster
-        cluster.populate(1, install_byteman=True).start(wait_for_binary_proto=True)
+        cluster.populate(1, install_byteman=True).start()
         node = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node)
@@ -461,7 +461,7 @@ class TestSecondaryIndexes(Tester):
         """
 
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node)
@@ -1178,7 +1178,7 @@ class TestPreJoinCallback(Tester):
         cluster.populate(1)
         node1 = cluster.nodelist()[0]
         node1.set_configuration_options(values={'initial_token': tokens[0]})
-        cluster.start(wait_other_notice=True)
+        cluster.start()
 
         # Create a table with 2i
         session = self.patient_cql_connection(node1)

--- a/snapshot_test.py
+++ b/snapshot_test.py
@@ -402,7 +402,7 @@ class TestArchiveCommitlog(SnapshotTester):
             for snapshot_dir in snapshot_dirs:
                 self.restore_snapshot(snapshot_dir, node1, 'ks', 'cf', 'basic')
 
-            cluster.start(wait_for_binary_proto=True)
+            cluster.start()
 
             session = self.patient_cql_connection(node1)
             node1.nodetool('refresh ks cf')
@@ -487,7 +487,7 @@ class TestArchiveCommitlog(SnapshotTester):
                          (r'^restore_directories=.*$', 'restore_directories={tmp_commitlog}'.format(
                           tmp_commitlog=tmp_commitlog))])
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         logger.debug("Creating initial connection")
         session = self.patient_cql_connection(node1)

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -164,7 +164,7 @@ class TestDynamicEndpointSnitch(Tester):
         # Delay reads on the degraded node by 50 milliseconds
         degraded_node.start(jvm_args=['-Dcassandra.test.read_iteration_delay_ms=50',
                                       '-Dcassandra.allow_unsafe_join=true'])
-        cluster.start(wait_for_binary_proto=30, wait_other_notice=True)
+        cluster.start()
 
         des = make_mbean('db', type='DynamicEndpointSnitch')
         read_stage = make_mbean('metrics', type='ThreadPools', path='request',

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -301,7 +301,7 @@ class TestSSTableGenerationAndLoading(TestBaseSStableLoader):
         @jira_ticket CASSANDRA-343
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node1 = cluster.nodelist()[0]
 
         # Makinge sure the cluster is ready to accept the subsequent
@@ -363,7 +363,7 @@ class TestSSTableGenerationAndLoading(TestBaseSStableLoader):
             session.execute("CREATE INDEX idx ON k.t(v)")
 
         cluster = self.cluster
-        cluster.populate(1, install_byteman=True).start(wait_for_binary_proto=True)
+        cluster.populate(1, install_byteman=True).start()
         node = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node)

--- a/sstablesplit_test.py
+++ b/sstablesplit_test.py
@@ -18,7 +18,7 @@ class TestSSTableSplit(Tester):
         after carrying out these operations.
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
         version = cluster.version()
 
@@ -91,7 +91,7 @@ class TestSSTableSplit(Tester):
         Check that sstablesplit doesn't crash when splitting a single sstable at the time.
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
 
         logger.debug("Run stress to insert data")

--- a/sstableutil_test.py
+++ b/sstableutil_test.py
@@ -37,7 +37,7 @@ class TestSSTableUtil(Tester):
         Check that we can list sstable files after a successful compaction (no temporary sstable files)
         """
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
 
         self._create_data(node, KeyspaceName, TableName, 100000)
@@ -58,7 +58,7 @@ class TestSSTableUtil(Tester):
         """
         log_file_name = 'debug.log'
         cluster = self.cluster
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         node = cluster.nodelist()[0]
 
         numrecords = 250000

--- a/streaming_test.py
+++ b/streaming_test.py
@@ -60,7 +60,7 @@ class TestStreaming(Tester):
         for i in range(0, len(nodes)):
             nodes[i].set_configuration_options(values={'initial_token': tokens[i]})
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         session = self.patient_cql_connection(nodes[0])
 

--- a/stress_tool_test.py
+++ b/stress_tool_test.py
@@ -43,7 +43,7 @@ class TestStressSparsenessRatio(Tester):
         A parameterized test for the `row-population-ratio` parameter to
         `cassandra-stress`.
         """
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
         node = self.cluster.nodelist()[0]
         node.stress(['write', 'n=1000', 'no-warmup', '-rate', 'threads=50', '-col', 'n=FIXED(50)',
                      '-insert', 'row-population-ratio={ratio_spec}'.format(ratio_spec=ratio_spec)])
@@ -65,7 +65,7 @@ class TestStressWrite(Tester):
         @jira_ticket CASSANDRA-14890
         A simple write stress test should be done very quickly
         """
-        self.cluster.populate(1).start(wait_for_binary_proto=True)
+        self.cluster.populate(1).start()
         node = self.cluster.nodelist()[0]
         node.stress(['write', 'err<0.9', 'n>1', '-rate', 'threads=1'])
         out, err, _ = node.run_cqlsh('describe table keyspace1.standard1')

--- a/thrift_hsha_test.py
+++ b/thrift_hsha_test.py
@@ -49,7 +49,7 @@ class TestThriftHSHA(Tester):
         cluster.populate(1)
         (node1,) = cluster.nodelist()
         remove_perf_disable_shared_mem(node1)
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         session = self.patient_cql_connection(node1)
         create_ks(session, 'test', 1)

--- a/thrift_test.py
+++ b/thrift_test.py
@@ -84,8 +84,7 @@ class TestThrift(Tester):
 
         # CASSANDRA-14092 - prevent max ttl tests from failing
         fixture_dtest_setup.cluster.start(jvm_args=['-Dcassandra.expiration_date_overflow_policy=CAP',
-                                                    '-Dcassandra.expiration_overflow_warning_interval_minutes=0'],
-                                          wait_for_binary_proto=True)
+                                                    '-Dcassandra.expiration_overflow_warning_interval_minutes=0'])
         fixture_dtest_setup.cluster.nodelist()[0].watch_log_for("Listening for thrift clients")  # Wait for the thrift port to open
         time.sleep(0.1)
         # this is ugly, but the whole test module is written against a global client

--- a/token_generator_test.py
+++ b/token_generator_test.py
@@ -84,7 +84,7 @@ class TestTokenGenerator(Tester):
             cluster._config_options.__delitem__('initial_token')
 
         assert not cluster.nodelist(), "nodelist() already initialized"
-        cluster.populate(nodes, use_vnodes=False, tokens=generated_tokens[0]).start(wait_for_binary_proto=True)
+        cluster.populate(nodes, use_vnodes=False, tokens=generated_tokens[0]).start()
         time.sleep(0.2)
 
         node = cluster.nodelist()[0]

--- a/topology_test.py
+++ b/topology_test.py
@@ -134,7 +134,7 @@ class TestTopology(Tester):
         """
         cluster = self.cluster
         cluster.populate(3)
-        cluster.start(wait_for_binary_proto=True, jvm_args=["-Dcassandra.size_recorder_interval=1"])
+        cluster.start(jvm_args=["-Dcassandra.size_recorder_interval=1"])
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node1)
@@ -161,7 +161,7 @@ class TestTopology(Tester):
         """
         cluster = self.cluster
         cluster.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
-        cluster.populate(2).start(wait_other_notice=True)
+        cluster.populate(2).start()
         node1, node2 = cluster.nodelist()
 
         session = self.patient_cql_connection(node2)
@@ -206,7 +206,7 @@ class TestTopology(Tester):
                                                         r'Remote peer 127.0.0.2:7000 failed stream session']
         cluster = self.cluster
         cluster.set_configuration_options(values={'stream_throughput_outbound_megabits_per_sec': 1})
-        cluster.populate(3, install_byteman=True).start(wait_other_notice=True)
+        cluster.populate(3, install_byteman=True).start()
         node1, node2, node3 = cluster.nodelist()
 
         session = self.patient_cql_connection(node2)
@@ -381,7 +381,7 @@ class TestTopology(Tester):
         self.fixture_dtest_setup.ignore_log_patterns = list(self.fixture_dtest_setup.ignore_log_patterns) + [
             rejoin_err]
 
-        self.cluster.populate(3).start(wait_for_binary_proto=True)
+        self.cluster.populate(3).start()
         node1, node2, node3 = self.cluster.nodelist()
 
         logger.debug('decommissioning...')
@@ -420,7 +420,7 @@ class TestTopology(Tester):
         """
         cluster = self.cluster
         self.fixture_dtest_setup.ignore_log_patterns = [r'Streaming error occurred', 'Stream failed']
-        cluster.populate(3).start(wait_other_notice=True)
+        cluster.populate(3).start()
 
         node1, node2 = cluster.nodelist()[0:2]
 
@@ -457,7 +457,7 @@ class TestTopology(Tester):
         @expected_errors ToolError when # nodes will drop below configured replicas in NTS/SimpleStrategy
         """
         cluster = self.cluster
-        cluster.populate([2, 2]).start(wait_for_binary_proto=True)
+        cluster.populate([2, 2]).start()
         node1, node2, node3, node4 = self.cluster.nodelist()
         session = self.patient_cql_connection(node2)
         session.execute("ALTER KEYSPACE system_distributed WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':'2'};")

--- a/transient_replication_ring_test.py
+++ b/transient_replication_ring_test.py
@@ -111,7 +111,7 @@ class TestTransientReplicationRing(Tester):
         print(self.cluster.get_install_dir())
         self.cluster.populate(3, tokens=self.tokens, debug=True, install_byteman=True)
         # self.cluster.populate(3, debug=True, install_byteman=True)
-        self.cluster.start(wait_other_notice=True, wait_for_binary_proto=True, jvm_args=['-Dcassandra.enable_nodelocal_queries=true'])
+        self.cluster.start(jvm_args=['-Dcassandra.enable_nodelocal_queries=true'])
 
         # enable shared memory
         for node in self.cluster.nodelist():

--- a/transient_replication_test.py
+++ b/transient_replication_test.py
@@ -213,7 +213,7 @@ class TransientReplicationBase(Tester):
                                                        'enable_transient_replication': True,
                                                        'dynamic_snitch': False})
         self.populate()
-        self.cluster.start(wait_other_notice=True, wait_for_binary_proto=True)
+        self.cluster.start()
 
         self.nodes = [patch_start(node) for node in self.cluster.nodelist()]
         self.set_nodes()

--- a/ttl_test.py
+++ b/ttl_test.py
@@ -373,7 +373,7 @@ class TestTTL(Tester):
 
         # Restart node with expiration_date_overflow_policy
         self.cluster.stop()
-        self.cluster.start(jvm_args=['-Dcassandra.expiration_date_overflow_policy={}'.format(policy)], wait_for_binary_proto=True)
+        self.cluster.start(jvm_args=['-Dcassandra.expiration_date_overflow_policy={}'.format(policy)])
         self.session1 = self.patient_cql_connection(self.cluster.nodelist()[0])
         self.session1.execute("USE ks;")
 
@@ -569,7 +569,7 @@ class TestRecoverNegativeExpirationDate(TestHelper):
         cluster = self.cluster
         if self.cluster.version() >= '4':
             cluster.set_configuration_options(values={'corrupted_tombstone_strategy': 'disabled'})
-        cluster.populate(1).start(wait_for_binary_proto=True)
+        cluster.populate(1).start()
         [node] = cluster.nodelist()
 
         session = self.patient_cql_connection(node)
@@ -611,7 +611,7 @@ class TestRecoverNegativeExpirationDate(TestHelper):
         logger.debug("Executed offline scrub on {}", str(scrubbed_sstables))
 
         logger.debug("Starting node again")
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         session = self.patient_cql_connection(node)
         session.execute("USE ks;")
 

--- a/upgrade_tests/compatibility_flag_test.py
+++ b/upgrade_tests/compatibility_flag_test.py
@@ -26,7 +26,7 @@ class TestCompatibilityFlag(Tester):
         node1, node2 = cluster.nodelist()
         cluster.set_install_dir(version=from_version)
         self.fixture_dtest_setup.reinitialize_cluster_for_different_version()
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1.drain()
         node1.watch_log_for("DRAINED")
@@ -48,7 +48,7 @@ class TestCompatibilityFlag(Tester):
         node1, node2 = cluster.nodelist()
         cluster.set_install_dir(version=from_version)
         self.fixture_dtest_setup.reinitialize_cluster_for_different_version()
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1.drain()
         node1.watch_log_for("DRAINED")

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -5458,7 +5458,7 @@ class TestCQL(UpgradeTester):
 
         self.cluster.stop()
         time.sleep(0.5)
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         time.sleep(0.5)
 
         for is_upgraded, cursor in self.do_upgrade(cursor):

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -129,7 +129,7 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
         if self.fixture_dtest_setup.enable_for_jolokia:
             remove_perf_disable_shared_mem(node1)
 
-        cluster.start(wait_for_binary_proto=True)
+        cluster.start()
 
         node1 = cluster.nodelist()[0]
         time.sleep(0.2)

--- a/user_types_test.py
+++ b/user_types_test.py
@@ -647,7 +647,7 @@ class TestUserTypes(Tester):
         # make sure we can define a table with a user type as a clustering column
         # and do a basic insert/query of data in that table.
         cluster = self.cluster
-        cluster.populate(3).start(wait_for_binary_proto=True)
+        cluster.populate(3).start()
         node1, node2, node3 = cluster.nodelist()
         session = self.patient_cql_connection(node1, consistency_level=ConsistencyLevel.LOCAL_QUORUM)
         create_ks(session, 'user_type_pkeys', 2)

--- a/write_failures_test.py
+++ b/write_failures_test.py
@@ -48,7 +48,7 @@ class TestWriteFailures(Tester):
         if start_rpc:
             self.cluster.set_configuration_options(values={'start_rpc': True})
 
-        self.cluster.start(wait_for_binary_proto=True)
+        self.cluster.start()
         self.nodes = list(self.cluster.nodes.values())
 
         session = self.patient_exclusive_cql_connection(self.nodes[0], protocol_version=self.protocol_version)


### PR DESCRIPTION
ever since https://github.com/riptano/ccm/pull/561 the defaults for `Cluster.start` have been:
`wait_for_binary_proto=True` and `wait_other_notice=True`.

still today:
https://github.com/riptano/ccm/blob/f6fd55a6bff53043d0c156480a72a7db6f477df5/ccmlib/cluster.py#L432-L433

so imo it makes sense to avoid specifying these redundant param values to shorten the code and also avoid confusion (because their presence could suggest that these are non-default values).

note that this is not true for `Node.start`:
https://github.com/riptano/ccm/blob/f6fd55a6bff53043d0c156480a72a7db6f477df5/ccmlib/node.py#L623-L632

so care was taken to only adjust `Cluster.start` places.

CI run:
https://ci-cassandra.apache.org/job/Cassandra-devbranch-dtest/20/ :large_blue_circle: 

potential followup:
`Node.start` defaults to `wait_other_notice=True` and a similar cleanup can be done there.