### PR TITLE
CASSANDRA-16328 - python upgrade tests include tests which are not impacted by the version under test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,6 +89,8 @@ def pytest_addoption(parser):
                      help="Enable JaCoCo Code Coverage Support")
     parser.addoption("--upgrade-version-selection", action="store", default="indev",
                      help="Specify whether to run indev, releases, or both")
+    parser.addoption("--upgrade-target-version-only", action="store_true", default=False,
+                     help="When running upgrade tests, only run tests upgrading to the current version")
 
 
 def sufficient_system_resources_for_resource_intensive_tests():

--- a/run_dtests.py
+++ b/run_dtests.py
@@ -104,6 +104,13 @@ class RunDTests():
             logging.root.setLevel(logging.DEBUG)
             logger.setLevel(logging.DEBUG)
 
+            # cause logger to go to stdout
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setLevel(logging.DEBUG)
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            handler.setFormatter(formatter)
+            logging.root.addHandler(handler)
+
 
         # Get dictionaries corresponding to each point in the configuration matrix
         # we want to run, then generate a config object for each of them.

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -29,9 +29,13 @@ def is_same_family_current_to_indev(origin, destination):
 
 class VersionSelectionStrategies(Enum):
     """
+    Allow all versions
+    """
+    ALL=(lambda origin, destination: True,)
+    """
     Test upgrading from indev -> indev, current -> current across versions, and current -> indev within a version
     """
-    BOTH=(lambda origin, destination: (origin.variant == destination.variant) or is_same_family_current_to_indev(origin,destination))
+    BOTH=(lambda origin, destination: (origin.variant == destination.variant) or is_same_family_current_to_indev(origin,destination),)
     """
     Exclusively test in development branches so your bug fixes show up
     """
@@ -151,7 +155,7 @@ MANIFEST = {
     indev_2_2_x: [indev_3_0_x, current_3_0_x, indev_3_11_x, current_3_11_x],
     current_2_2_x: [indev_2_2_x, indev_3_0_x, current_3_0_x, indev_3_11_x, current_3_11_x],
 
-    indev_3_0_x: [indev_3_11_x, current_3_11_x],
+    indev_3_0_x: [indev_3_11_x, current_3_11_x, indev_trunk],
     current_3_0_x: [indev_3_0_x, indev_3_11_x, current_3_11_x, indev_trunk],
 
     current_3_11_x: [indev_3_11_x, indev_trunk],

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -133,7 +133,7 @@ indev_2_2_x = VersionMeta(name='indev_2_2_x', family='2.2', variant='indev', ver
 current_2_2_x = VersionMeta(name='current_2_2_x', family='2.2', variant='current', version='2.2.13', min_proto_v=1, max_proto_v=4, java_versions=(7, 8))
 
 indev_3_0_x = VersionMeta(name='indev_3_0_x', family='3.0', variant='indev', version='github:apache/cassandra-3.0', min_proto_v=3, max_proto_v=4, java_versions=(8,))
-current_3_0_x = VersionMeta(name='current_3_0_x', family='3.0', variant='current', version='3.0.17', min_proto_v=3, max_proto_v=4, java_versions=(8,))
+current_3_0_x = VersionMeta(name='current_3_0_x', family='3.0', variant='current', version='3.0.23', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 
 indev_3_11_x = VersionMeta(name='indev_3_11_x', family='3.11', variant='indev', version='github:apache/cassandra-3.11', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 current_3_11_x = VersionMeta(name='current_3_11_x', family='3.11', variant='current', version='github:apache/cassandra-3.11', min_proto_v=3, max_proto_v=4, java_versions=(8,))


### PR DESCRIPTION
Tests included with the new flag against trunk

```
upgrade_crc_check_chance_test.py::TestCrcCheckChanceUpgrade::test_crc_check_chance_upgrade
upgrade_internal_auth_test.py::TestAuthUpgrade::test_upgrade_to_22
upgrade_internal_auth_test.py::TestAuthUpgrade::test_upgrade_to_30
upgrade_internal_auth_test.py::TestAuthUpgrade::test_upgrade_legacy_table
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_simple_bootstrap_with_ssl
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_simple_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_bootstrap_on_write_survey
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_simple_bootstrap_small_keepalive_period
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_simple_bootstrap_nodata
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_read_from_bootstrapped_node
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_bootstrap_waits_for_streaming_to_finish
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_consistent_range_movement_true_with_replica_down_should_fail
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_consistent_range_movement_false_with_replica_down_should_succeed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_consistent_range_movement_true_with_rf1_should_fail
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_consistent_range_movement_false_with_rf1_should_succeed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_resumable_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_bootstrap_with_reset_bootstrap_state
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_manual_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_local_quorum_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_shutdown_wiped_node_cannot_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_killed_wiped_node_cannot_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_decommissioned_wiped_node_can_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_decommissioned_wiped_node_can_gossip_to_single_seed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_failed_bootstrap_wiped_node_can_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_node_cannot_join_as_hibernating_node_without_replace_address
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_simultaneous_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_cleanup
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrap::test_bootstrap_binary_disabled
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simple_bootstrap_with_ssl
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simple_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_bootstrap_on_write_survey
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simple_bootstrap_small_keepalive_period
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simple_bootstrap_nodata
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_read_from_bootstrapped_node
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_bootstrap_waits_for_streaming_to_finish
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_consistent_range_movement_true_with_replica_down_should_fail
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_consistent_range_movement_false_with_replica_down_should_succeed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_consistent_range_movement_true_with_rf1_should_fail
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_consistent_range_movement_false_with_rf1_should_succeed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_resumable_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_bootstrap_with_reset_bootstrap_state
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_manual_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_local_quorum_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_shutdown_wiped_node_cannot_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_killed_wiped_node_cannot_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_decommissioned_wiped_node_can_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_decommissioned_wiped_node_can_gossip_to_single_seed
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_failed_bootstrap_wiped_node_can_join
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_node_cannot_join_as_hibernating_node_without_replace_address
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simultaneous_bootstrap
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_cleanup
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_bootstrap_binary_disabled
upgrade_tests/bootstrap_upgrade_test.py::TestBootstrapUpgrade::test_simple_bootstrap_mixed_versions
upgrade_tests/compatibility_flag_test.py::TestCompatibilityFlag::test__compatibility_flag_on_3014
upgrade_tests/compatibility_flag_test.py::TestCompatibilityFlag::test__compatibility_flag_off_3014
upgrade_tests/cql_tests.py::cls::test_static_cf
upgrade_tests/cql_tests.py::cls::test_large_collection_errors
upgrade_tests/cql_tests.py::cls::test_noncomposite_static_cf
upgrade_tests/cql_tests.py::cls::test_dynamic_cf
upgrade_tests/cql_tests.py::cls::test_dense_cf
upgrade_tests/cql_tests.py::cls::test_sparse_cf
upgrade_tests/cql_tests.py::cls::test_limit_ranges
upgrade_tests/cql_tests.py::cls::test_limit_multiget
upgrade_tests/cql_tests.py::cls::test_simple_tuple_query
upgrade_tests/cql_tests.py::cls::test_limit_sparse
upgrade_tests/cql_tests.py::cls::test_counters
upgrade_tests/cql_tests.py::cls::test_indexed_with_eq
upgrade_tests/cql_tests.py::cls::test_select_key_in
upgrade_tests/cql_tests.py::cls::test_exclusive_slice
upgrade_tests/cql_tests.py::cls::test_in_clause_wide_rows
upgrade_tests/cql_tests.py::cls::test_order_by
upgrade_tests/cql_tests.py::cls::test_more_order_by
upgrade_tests/cql_tests.py::cls::test_order_by_validation
upgrade_tests/cql_tests.py::cls::test_order_by_with_in
upgrade_tests/cql_tests.py::cls::test_reversed_comparator
upgrade_tests/cql_tests.py::cls::test_null_support
upgrade_tests/cql_tests.py::cls::test_nameless_index
upgrade_tests/cql_tests.py::cls::test_deletion
upgrade_tests/cql_tests.py::cls::test_count
upgrade_tests/cql_tests.py::cls::test_batch
upgrade_tests/cql_tests.py::cls::test_token_range
upgrade_tests/cql_tests.py::cls::test_timestamp_and_ttl
upgrade_tests/cql_tests.py::cls::test_no_range_ghost
upgrade_tests/cql_tests.py::cls::test_undefined_column_handling
upgrade_tests/cql_tests.py::cls::test_range_tombstones
upgrade_tests/cql_tests.py::cls::test_range_tombstones_compaction
upgrade_tests/cql_tests.py::cls::test_delete_row
upgrade_tests/cql_tests.py::cls::test_range_query_2ndary
upgrade_tests/cql_tests.py::cls::test_set
upgrade_tests/cql_tests.py::cls::test_map
upgrade_tests/cql_tests.py::cls::test_list
upgrade_tests/cql_tests.py::cls::test_multi_collection
upgrade_tests/cql_tests.py::cls::test_range_query
upgrade_tests/cql_tests.py::cls::test_composite_row_key
upgrade_tests/cql_tests.py::cls::test_cql3_insert_thrift
upgrade_tests/cql_tests.py::cls::test_cql3_non_compound_range_tombstones
upgrade_tests/cql_tests.py::cls::test_row_existence
upgrade_tests/cql_tests.py::cls::test_only_pk
upgrade_tests/cql_tests.py::cls::test_no_clustering
upgrade_tests/cql_tests.py::cls::test_date
upgrade_tests/cql_tests.py::cls::test_range_slice
upgrade_tests/cql_tests.py::cls::test_composite_index_with_pk
upgrade_tests/cql_tests.py::cls::test_limit_bugs
upgrade_tests/cql_tests.py::cls::test_npe_composite_table_slice
upgrade_tests/cql_tests.py::cls::test_order_by_multikey
upgrade_tests/cql_tests.py::cls::test_remove_range_slice
upgrade_tests/cql_tests.py::cls::test_indexes_composite
upgrade_tests/cql_tests.py::cls::test_refuse_in_with_indexes
upgrade_tests/cql_tests.py::cls::test_reversed_compact
upgrade_tests/cql_tests.py::cls::test_reversed_compact_multikey
upgrade_tests/cql_tests.py::cls::test_collection_and_regular
upgrade_tests/cql_tests.py::cls::test_batch_and_list
upgrade_tests/cql_tests.py::cls::test_boolean
upgrade_tests/cql_tests.py::cls::test_multiordering
upgrade_tests/cql_tests.py::cls::test_returned_null
upgrade_tests/cql_tests.py::cls::test_multi_list_set
upgrade_tests/cql_tests.py::cls::test_composite_index_collections
upgrade_tests/cql_tests.py::cls::test_truncate_clean_cache
upgrade_tests/cql_tests.py::cls::test_range_with_deletes
upgrade_tests/cql_tests.py::cls::test_collection_function
upgrade_tests/cql_tests.py::cls::test_composite_partition_key_validation
upgrade_tests/cql_tests.py::cls::test_multi_in
upgrade_tests/cql_tests.py::cls::test_multi_in_compact
upgrade_tests/cql_tests.py::cls::test_multi_in_compact_non_composite
upgrade_tests/cql_tests.py::cls::test_large_clustering_in
upgrade_tests/cql_tests.py::cls::test_timeuuid
upgrade_tests/cql_tests.py::cls::test_float_with_exponent
upgrade_tests/cql_tests.py::cls::test_compact_metadata
upgrade_tests/cql_tests.py::cls::test_query_compact_tables_during_upgrade
upgrade_tests/cql_tests.py::cls::test_clustering_indexing
upgrade_tests/cql_tests.py::cls::test_edge_2i_on_complex_pk
upgrade_tests/cql_tests.py::cls::test_end_of_component_as_end_key
upgrade_tests/cql_tests.py::cls::test_ticket_5230
upgrade_tests/cql_tests.py::cls::test_conversion_functions
upgrade_tests/cql_tests.py::cls::test_IN_clause_on_last_key
upgrade_tests/cql_tests.py::cls::test_function_and_reverse_type
upgrade_tests/cql_tests.py::cls::test_NPE_during_select_with_token
upgrade_tests/cql_tests.py::cls::test_empty_blob
upgrade_tests/cql_tests.py::cls::test_rename
upgrade_tests/cql_tests.py::cls::test_clustering_order_and_functions
upgrade_tests/cql_tests.py::cls::test_conditional_update
upgrade_tests/cql_tests.py::cls::test_non_eq_conditional_update
upgrade_tests/cql_tests.py::cls::test_conditional_delete
upgrade_tests/cql_tests.py::cls::test_range_key_ordered
upgrade_tests/cql_tests.py::cls::test_select_with_alias
upgrade_tests/cql_tests.py::cls::test_nonpure_function_collection
upgrade_tests/cql_tests.py::cls::test_empty_in
upgrade_tests/cql_tests.py::cls::test_collection_flush
upgrade_tests/cql_tests.py::cls::test_select_distinct
upgrade_tests/cql_tests.py::cls::test_select_distinct_with_deletions
upgrade_tests/cql_tests.py::cls::test_function_with_null
upgrade_tests/cql_tests.py::cls::test_cas_simple
upgrade_tests/cql_tests.py::cls::test_internal_application_error_on_select
upgrade_tests/cql_tests.py::cls::test_store_sets_with_if_not_exists
upgrade_tests/cql_tests.py::cls::test_add_deletion_info_in_unsorted_column
upgrade_tests/cql_tests.py::cls::test_column_name_validation
upgrade_tests/cql_tests.py::cls::test_user_types
upgrade_tests/cql_tests.py::cls::test_more_user_types
upgrade_tests/cql_tests.py::cls::test_intersection_logic_returns_empty_result
upgrade_tests/cql_tests.py::cls::test_large_count
upgrade_tests/cql_tests.py::cls::test_collection_indexing
upgrade_tests/cql_tests.py::cls::test_map_keys_indexing
upgrade_tests/cql_tests.py::cls::test_nan_infinity
upgrade_tests/cql_tests.py::cls::test_static_columns
upgrade_tests/cql_tests.py::cls::test_static_columns_cas
upgrade_tests/cql_tests.py::cls::test_static_columns_with_2i
upgrade_tests/cql_tests.py::cls::test_static_columns_with_distinct
upgrade_tests/cql_tests.py::cls::test_select_count_paging
upgrade_tests/cql_tests.py::cls::test_cas_and_ttl
upgrade_tests/cql_tests.py::cls::test_tuple_notation
upgrade_tests/cql_tests.py::cls::test_v2_protocol_IN_with_tuples
upgrade_tests/cql_tests.py::cls::test_in_with_desc_order
upgrade_tests/cql_tests.py::cls::test_in_order_by_without_selecting
upgrade_tests/cql_tests.py::cls::test_cas_and_compact
upgrade_tests/cql_tests.py::cls::test_whole_list_conditional
upgrade_tests/cql_tests.py::cls::test_list_item_conditional
upgrade_tests/cql_tests.py::cls::test_expanded_list_item_conditional
upgrade_tests/cql_tests.py::cls::test_whole_set_conditional
upgrade_tests/cql_tests.py::cls::test_whole_map_conditional
upgrade_tests/cql_tests.py::cls::test_map_item_conditional
upgrade_tests/cql_tests.py::cls::test_expanded_map_item_conditional
upgrade_tests/cql_tests.py::cls::test_cas_and_list_index
upgrade_tests/cql_tests.py::cls::test_static_with_limit
upgrade_tests/cql_tests.py::cls::test_static_with_empty_clustering
upgrade_tests/cql_tests.py::cls::test_limit_compact_table
upgrade_tests/cql_tests.py::cls::test_key_index_with_reverse_clustering
upgrade_tests/cql_tests.py::cls::test_invalid_custom_timestamp
upgrade_tests/cql_tests.py::cls::test_clustering_order_in
upgrade_tests/cql_tests.py::cls::test_end_of_component_uses_oecBound
upgrade_tests/cql_tests.py::cls::test_SIM_assertion_error
upgrade_tests/cql_tests.py::cls::test_blobAs_functions
upgrade_tests/cql_tests.py::cls::test_invalid_string_literals
upgrade_tests/cql_tests.py::cls::test_negative_timestamp
upgrade_tests/cql_tests.py::cls::test_select_map_key_single_row
upgrade_tests/cql_tests.py::cls::test_select_set_key_single_row
upgrade_tests/cql_tests.py::cls::test_select_list_key_single_row
upgrade_tests/cql_tests.py::cls::test_select_map_key_multi_row
upgrade_tests/cql_tests.py::cls::test_select_set_key_multi_row
upgrade_tests/cql_tests.py::cls::test_select_list_key_multi_row
upgrade_tests/cql_tests.py::cls::test_deleted_row_select
upgrade_tests/cql_tests.py::cls::test_secondary_index_query
upgrade_tests/cql_tests.py::cls::test_tracing_prevents_startup_after_upgrading
upgrade_tests/cql_tests.py::cls::test_materialized_view_simple
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_cf
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_large_collection_errors
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_noncomposite_static_cf
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_dynamic_cf
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_cf
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_cf
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_ranges
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_multiget
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_simple_tuple_query
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_sparse
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_counters
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_indexed_with_eq
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_key_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_exclusive_slice
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_in_clause_wide_rows
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_more_order_by
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_validation
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_with_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_comparator
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_null_support
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_nameless_index
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_deletion
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_count
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_batch
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_token_range
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_timestamp_and_ttl
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_no_range_ghost
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_undefined_column_handling
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_tombstones
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_tombstones_compaction
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_delete_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_query_2ndary
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_set
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_map
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_list
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_collection
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_query
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_row_key
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cql3_insert_thrift
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cql3_non_compound_range_tombstones
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_row_existence
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_only_pk
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_no_clustering
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_date
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_slice
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_index_with_pk
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_bugs
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_npe_composite_table_slice
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_multikey
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_remove_range_slice
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_indexes_composite
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_refuse_in_with_indexes
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_compact
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_compact_multikey
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_and_regular
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_batch_and_list
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_boolean
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multiordering
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_returned_null
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_list_set
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_index_collections
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_truncate_clean_cache
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_with_deletes
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_function
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_partition_key_validation
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in_compact
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in_compact_non_composite
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_large_clustering_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_timeuuid
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_float_with_exponent
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_compact_metadata
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_query_compact_tables_during_upgrade
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_indexing
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_edge_2i_on_complex_pk
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_end_of_component_as_end_key
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_ticket_5230
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_conversion_functions
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_IN_clause_on_last_key
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_function_and_reverse_type
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_NPE_during_select_with_token
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_empty_blob
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_rename
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_order_and_functions
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_conditional_update
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_non_eq_conditional_update
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_conditional_delete
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_range_key_ordered
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_with_alias
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_nonpure_function_collection
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_empty_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_flush
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_distinct
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_distinct_with_deletions
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_function_with_null
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_simple
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_internal_application_error_on_select
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_store_sets_with_if_not_exists
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_add_deletion_info_in_unsorted_column
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_column_name_validation
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_user_types
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_more_user_types
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_intersection_logic_returns_empty_result
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_large_count
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_indexing
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_map_keys_indexing
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_nan_infinity
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_cas
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_with_2i
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_with_distinct
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_count_paging
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_ttl
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_tuple_notation
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_v2_protocol_IN_with_tuples
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_in_with_desc_order
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_in_order_by_without_selecting
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_compact
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_list_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_list_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_expanded_list_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_set_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_map_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_map_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_expanded_map_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_list_index
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_with_limit
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_with_empty_clustering
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_compact_table
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_key_index_with_reverse_clustering
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_invalid_custom_timestamp
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_order_in
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_end_of_component_uses_oecBound
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_SIM_assertion_error
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_blobAs_functions
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_invalid_string_literals
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_negative_timestamp
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_map_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_set_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_list_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_map_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_set_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_select_list_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_deleted_row_select
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_secondary_index_query
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_tracing_prevents_startup_after_upgrading
upgrade_tests/cql_tests.py::TestCQLNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_materialized_view_simple
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_cf
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_large_collection_errors
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_noncomposite_static_cf
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_dynamic_cf
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_cf
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_cf
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_ranges
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_multiget
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_simple_tuple_query
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_sparse
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_counters
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_indexed_with_eq
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_key_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_exclusive_slice
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_in_clause_wide_rows
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_more_order_by
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_validation
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_with_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_comparator
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_null_support
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_nameless_index
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_deletion
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_count
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_batch
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_token_range
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_timestamp_and_ttl
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_no_range_ghost
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_undefined_column_handling
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_tombstones
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_tombstones_compaction
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_delete_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_query_2ndary
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_set
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_map
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_list
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_collection
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_query
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_row_key
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cql3_insert_thrift
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cql3_non_compound_range_tombstones
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_row_existence
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_only_pk
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_no_clustering
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_date
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_slice
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_index_with_pk
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_bugs
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_npe_composite_table_slice
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_order_by_multikey
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_remove_range_slice
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_indexes_composite
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_refuse_in_with_indexes
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_compact
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_reversed_compact_multikey
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_and_regular
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_batch_and_list
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_boolean
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multiordering
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_returned_null
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_list_set
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_index_collections
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_truncate_clean_cache
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_with_deletes
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_function
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_composite_partition_key_validation
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in_compact
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multi_in_compact_non_composite
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_large_clustering_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_timeuuid
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_float_with_exponent
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_compact_metadata
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_query_compact_tables_during_upgrade
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_indexing
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_edge_2i_on_complex_pk
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_end_of_component_as_end_key
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_ticket_5230
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_conversion_functions
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_IN_clause_on_last_key
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_function_and_reverse_type
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_NPE_during_select_with_token
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_empty_blob
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_rename
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_order_and_functions
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_conditional_update
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_non_eq_conditional_update
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_conditional_delete
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_range_key_ordered
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_with_alias
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_nonpure_function_collection
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_empty_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_flush
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_distinct
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_distinct_with_deletions
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_function_with_null
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_simple
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_internal_application_error_on_select
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_store_sets_with_if_not_exists
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_add_deletion_info_in_unsorted_column
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_column_name_validation
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_user_types
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_more_user_types
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_intersection_logic_returns_empty_result
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_large_count
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_collection_indexing
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_map_keys_indexing
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_nan_infinity
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_cas
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_with_2i
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_with_distinct
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_count_paging
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_ttl
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_tuple_notation
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_v2_protocol_IN_with_tuples
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_in_with_desc_order
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_in_order_by_without_selecting
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_compact
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_list_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_list_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_expanded_list_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_set_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_whole_map_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_map_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_expanded_map_item_conditional
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cas_and_list_index
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_with_limit
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_with_empty_clustering
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_limit_compact_table
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_key_index_with_reverse_clustering
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_invalid_custom_timestamp
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_clustering_order_in
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_end_of_component_uses_oecBound
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_SIM_assertion_error
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_blobAs_functions
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_invalid_string_literals
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_negative_timestamp
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_map_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_set_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_list_key_single_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_map_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_set_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_select_list_key_multi_row
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_deleted_row_select
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_secondary_index_query
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_tracing_prevents_startup_after_upgrading
upgrade_tests/cql_tests.py::TestCQLNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_materialized_view_simple
upgrade_tests/drop_compact_storage_upgrade_test.py::TestDropCompactStorage::test_drop_compact_storage
upgrade_tests/paging_test.py::cls::test_single_partition_deletions
upgrade_tests/paging_test.py::cls::test_multiple_partition_deletions
upgrade_tests/paging_test.py::cls::test_single_row_deletions
upgrade_tests/paging_test.py::cls::test_single_cell_deletions
upgrade_tests/paging_test.py::cls::test_multiple_cell_deletions
upgrade_tests/paging_test.py::cls::test_ttl_deletions
upgrade_tests/paging_test.py::cls::test_failure_threshold_deletions
upgrade_tests/paging_test.py::TestPagingSizeNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_no_results
upgrade_tests/paging_test.py::TestPagingSizeNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_less_results_than_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_more_results_than_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_equal_results_to_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_undefined_page_size_default
upgrade_tests/paging_test.py::TestPagingSizeNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_no_results
upgrade_tests/paging_test.py::TestPagingSizeNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_less_results_than_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_more_results_than_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_equal_results_to_page_size
upgrade_tests/paging_test.py::TestPagingSizeNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_undefined_page_size_default
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_order_by
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_order_by_reversed
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_limit
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_with_allow_filtering
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_order_by
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_order_by_reversed
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_limit
upgrade_tests/paging_test.py::TestPagingWithModifiersNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_with_allow_filtering
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_basic_paging
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_basic_compound_paging
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_a_single_wide_row
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_across_multi_wide_rows
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_using_secondary_indexes
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_paging
upgrade_tests/paging_test.py::TestPagingDataNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_using_secondary_indexes_with_static_cols
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_basic_paging
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_basic_compound_paging
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_a_single_wide_row
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_across_multi_wide_rows
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_using_secondary_indexes
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_static_columns_paging
upgrade_tests/paging_test.py::TestPagingDataNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_paging_using_secondary_indexes_with_static_cols
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_data_change_impacting_earlier_page
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_data_change_impacting_later_page
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_row_TTL_expiry_during_paging
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_cell_TTL_expiry_during_paging
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_data_change_impacting_earlier_page
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_data_change_impacting_later_page
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_row_TTL_expiry_during_paging
upgrade_tests/paging_test.py::TestPagingDatasetChangesNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_cell_TTL_expiry_during_paging
upgrade_tests/paging_test.py::TestPagingQueryIsolationNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_query_isolation
upgrade_tests/paging_test.py::TestPagingQueryIsolationNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_query_isolation
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_single_partition_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multiple_partition_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_single_row_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_single_cell_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_multiple_cell_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_ttl_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_failure_threshold_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_single_partition_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multiple_partition_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_single_row_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_single_cell_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_multiple_cell_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_ttl_deletions
upgrade_tests/paging_test.py::TestPagingWithDeletionsNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_failure_threshold_deletions
upgrade_tests/regression_test.py::cls::test_10822
upgrade_tests/regression_test.py::cls::test13294
upgrade_tests/regression_test.py::cls::test_schema_agreement
upgrade_tests/regression_test.py::TestForRegressionsUpgrade_indev_3_11_x_To_indev_trunk::test_10822
upgrade_tests/regression_test.py::TestForRegressionsUpgrade_indev_3_11_x_To_indev_trunk::test13294
upgrade_tests/regression_test.py::TestForRegressionsUpgrade_indev_3_11_x_To_indev_trunk::test_schema_agreement
upgrade_tests/repair_test.py::TestUpgradeRepair::test_repair_after_upgrade
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestBaseSStableLoader::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_update_and_drop_column
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_clustered_CQL_table
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_clustered_compact_table
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_unclustered_CQL_table
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_unclustered_compact_table
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_statics
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_wide_partition_and_statics
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_wide_partition
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_wide_partition_reversed
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_index
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_range_tombstones
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_range_and_collection_tombstones
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_range_tombstone_eoc_0
upgrade_tests/storage_engine_upgrade_test.py::TestStorageEngineUpgrade::test_upgrade_with_range_tombstone_ae
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_update_and_drop_column
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_clustered_CQL_table
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_clustered_compact_table
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_unclustered_CQL_table
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_unclustered_compact_table
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_statics
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_wide_partition_and_statics
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_wide_partition
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_wide_partition_reversed
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_index
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_range_tombstones
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_range_and_collection_tombstones
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_range_tombstone_eoc_0
upgrade_tests/storage_engine_upgrade_test.py::TestBootstrapAfterUpgrade::test_upgrade_with_range_tombstone_ae
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadKaCompactSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadLaCompactSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdCompactSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneSStables::test_sstableloader_with_mv
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_none_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_none_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_none_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_snappy_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_snappy_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_snappy_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_deflate_to_none
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_deflate_to_snappy
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_compression_deflate_to_deflate
upgrade_tests/storage_engine_upgrade_test.py::TestLoadMdThreeOneOneCompactSStables::test_sstableloader_with_mv
upgrade_tests/thrift_upgrade_test.py::cls::test_dense_supercolumn
upgrade_tests/thrift_upgrade_test.py::cls::test_dense_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::cls::test_sparse_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::cls::test_sparse_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes3RF3_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_dense_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_supercolumn_with_renames
upgrade_tests/thrift_upgrade_test.py::TestThriftNodes2RF1_Upgrade_indev_3_11_x_To_indev_trunk::test_sparse_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestUpgradeSuperColumnsThrough::test_dense_supercolumn_3_0_created
upgrade_tests/thrift_upgrade_test.py::TestUpgradeSuperColumnsThrough::test_dense_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestUpgradeSuperColumnsThrough::test_sparse_supercolumn
upgrade_tests/thrift_upgrade_test.py::TestUpgradeTo40::test_keys_index_3_0_created
upgrade_tests/thrift_upgrade_test.py::TestUpgradeTo40::test_keys_index_3_11_created
upgrade_tests/thrift_upgrade_test.py::TestUpgradeTo40::test_keys_index_3_x_created
upgrade_tests/upgrade_supercolumns_test.py::TestSCUpgrade::test_upgrade_super_columns_through_all_versions
upgrade_tests/upgrade_supercolumns_test.py::TestSCUpgrade::test_upgrade_super_columns_through_limited_versions
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_EndsAt_3_11_X::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_EndsAt_3_11_X::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_EndsAt_3_11_X::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_EndsAt_3_11_X::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_RandomPartitioner_EndsAt_3_11_X_HEAD::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_RandomPartitioner_EndsAt_3_11_X_HEAD::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_RandomPartitioner_EndsAt_3_11_X_HEAD::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV3Upgrade_AllVersions_RandomPartitioner_EndsAt_3_11_X_HEAD::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_EndsAt_Trunk_HEAD::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_EndsAt_Trunk_HEAD::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_EndsAt_Trunk_HEAD::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_EndsAt_Trunk_HEAD::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestProtoV4Upgrade_AllVersions_RandomPartitioner_EndsAt_Trunk_HEAD::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_bootstrap
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade_indev_3_11_x_To_indev_trunk::test_bootstrap_multidc
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade::test_parallel_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade::test_rolling_upgrade
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade::test_parallel_upgrade_with_internode_ssl
upgrade_tests/upgrade_through_versions_test.py::TestUpgrade::test_rolling_upgrade_with_internode_ssl
upgrade_tests/upgrade_udtfix_test.py::cls::test_udtfix_in_sstable
upgrade_tests/upgrade_udtfix_test.py::cls::test_udtfix_in_messaging
upgrade_tests/upgrade_udtfix_test.py::UpgradeUDTFixTest_Upgrade_indev_3_11_x_To_indev_trunk::test_udtfix_in_sstable
upgrade_tests/upgrade_udtfix_test.py::UpgradeUDTFixTest_Upgrade_indev_3_11_x_To_indev_trunk::test_udtfix_in_messaging
```