### PR TITLE
CASSANDRA-16181 - 4.0 Quality: Replication Test Audit

### DIFF
--- a/batch_test.py
+++ b/batch_test.py
@@ -12,6 +12,7 @@ from tools.assertions import (assert_all, assert_invalid, assert_one,
 from tools.jmxutils import (JolokiaAgent, make_mbean)
 
 since = pytest.mark.since
+ported_to_in_jvm = pytest.mark.ported_to_in_jvm
 logger = logging.getLogger(__name__)
 
 
@@ -288,6 +289,7 @@ class TestBatch(Tester):
         assert_one(session, "SELECT * FROM users", [0, 'Jack', 'Sparrow'])
         assert_one(session, "SELECT * FROM dogs", [0, 'Pluto'])
 
+    @ported_to_in_jvm('4.0')
     @since('3.0', max_version='3.x')
     def test_logged_batch_compatibility_1(self):
         """
@@ -297,6 +299,7 @@ class TestBatch(Tester):
         """
         self._logged_batch_compatibility_test(0, 1, 'github:apache/cassandra-2.2', 2, 4)
 
+    @ported_to_in_jvm('4.0')
     @since('3.0', max_version='3.x')
     def test_batchlog_replay_compatibility_1(self):
         """
@@ -326,6 +329,7 @@ class TestBatch(Tester):
         """
         self._logged_batch_compatibility_test(0, 2, 'github:apache/cassandra-2.1', 1, 3)
 
+    @ported_to_in_jvm('4.0')
     @since('3.0', max_version='3.x')
     def test_logged_batch_compatibility_4(self):
         """
@@ -335,6 +339,7 @@ class TestBatch(Tester):
         """
         self._logged_batch_compatibility_test(2, 2, 'github:apache/cassandra-2.2', 1, 4)
 
+    @ported_to_in_jvm('4.0')
     @since('3.0', max_version='3.x')
     def test_batchlog_replay_compatibility_4(self):
         """

--- a/conftest.py
+++ b/conftest.py
@@ -468,52 +468,11 @@ def _skip_ported_msg(current_running_version, ported_from_version):
 @pytest.fixture(autouse=True)
 def fixture_ported_to_in_jvm(request, fixture_dtest_setup):
     """
-    Adds a new mark called 'ported_to_in_jvm' which denotes that a test was ported to jvm-dtest.
+    Adds a new mark called 'ported_to_in_jvm' which denotes that a test was ported to an in-JVM dtest.
 
-    As of this point in time there are weaknesses of jvm-dtest which require these tests to still
-    be run in the cases not covered by jvm-dtest; namely vnode.
+    In-JVM dtests do not currently support running with vnodes, so tests that use this annotation will
+    still be run around those configurations.
     """
-    marker = request.node.get_closest_marker('ported_to_in_jvm')
-    if marker and not request.config.getoption("--use-vnodes"):
-
-        if not marker.args:
-            pytest.skip("ported to in-jvm")
-
-        from_str = marker.args[0]
-        ported_from_version = LooseVersion(from_str)
-
-        # For upgrade tests don't run the test if any of the involved versions
-        # are excluded by the annotation
-        if hasattr(request.cls, "UPGRADE_PATH"):
-            upgrade_path = request.cls.UPGRADE_PATH
-            ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.starting_meta.version)
-            starting_version = get_version_from_build(ccm_repo_cache_dir)
-            skip_msg = _skip_ported_msg(starting_version, ported_from_version)
-            if skip_msg:
-                pytest.skip(skip_msg)
-            ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.upgrade_meta.version)
-            ending_version = get_version_from_build(ccm_repo_cache_dir)
-            skip_msg = _skip_ported_msg(ending_version, ported_from_version)
-            if skip_msg:
-                pytest.skip(skip_msg)
-        else:
-            # For regular tests the value in the current cluster actually means something so we should
-            # use that to check.
-            # Use cassandra_version_from_build as it's guaranteed to be a LooseVersion
-            # whereas cassandra_version may be a string if set in the cli options
-            current_running_version = fixture_dtest_setup.dtest_config.cassandra_version_from_build
-            skip_msg = _skip_ported_msg(current_running_version, ported_from_version)
-            if skip_msg:
-                pytest.skip(skip_msg)
-
-
-def _skip_ported_msg(current_running_version, ported_from_version):
-    if loose_version_compare(current_running_version, ported_from_version) >= 0:
-        return "ported to in-JVM from %s >= %s" % (ported_from_version, current_running_version)
-
-
-@pytest.fixture(autouse=True)
-def fixture_ported_to_in_jvm(request, fixture_dtest_setup):
     marker = request.node.get_closest_marker('ported_to_in_jvm')
     if marker and not request.config.getoption("--use-vnodes"):
 

--- a/hintedhandoff_test.py
+++ b/hintedhandoff_test.py
@@ -10,6 +10,7 @@ from tools.data import create_c1c2_table, insert_c1c2, query_c1c2
 from tools.assertions import assert_stderr_clean
 
 since = pytest.mark.since
+ported_to_in_jvm = pytest.mark.ported_to_in_jvm
 logger = logging.getLogger(__name__)
 
 
@@ -71,6 +72,7 @@ class TestHintedHandoffConfig(Tester):
             else:
                 query_c1c2(session, n, ConsistencyLevel.ONE, tolerate_missing=True, must_be_missing=True)
 
+    @ported_to_in_jvm('4.0')
     def test_nodetool(self):
         """
         Test various nodetool commands
@@ -177,6 +179,7 @@ class TestHintedHandoffConfig(Tester):
 
 class TestHintedHandoff(Tester):
 
+    @ported_to_in_jvm('4.0')
     @pytest.mark.no_vnodes
     def test_hintedhandoff_decom(self):
         self.cluster.populate(4).start()


### PR DESCRIPTION
add annotations to stop running batch write and hinted handoff tests that have been ported to the in-JVM framework