### PR TITLE
Protocol v5 is only supported in 4.0+

### DIFF
--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -385,7 +385,7 @@ class TestVariousNotifications(Tester):
         read_request_timeout_in_ms.
         @jira_ticket CASSANDRA-7886
         """
-        have_v5_protocol = self.cluster.version() >= LooseVersion('3.10')
+        have_v5_protocol = self.supports_v5_protocol(self.cluster.version())
 
         self.fixture_dtest_setup.allow_log_errors = True
         self.cluster.set_configuration_options(

--- a/read_failures_test.py
+++ b/read_failures_test.py
@@ -106,7 +106,7 @@ class TestReadFailures(Tester):
         self._insert_tombstones(session, 600)
         self._perform_cql_statement(session, "SELECT value FROM tombstonefailure")
 
-    @since('3.10')
+    @since('4.0')
     def test_tombstone_failure_v5(self):
         """
         A failed read due to tombstones at v5 should result in a ReadFailure with


### PR DESCRIPTION
The version of `v5-beta` in pre-4.0 versions of C* is incompatible with the finalised version in 4.0. Since the drivers were updated to support this, dtests should not test v5 on older C* versions.