### PR TITLE
Remove references to run_dtests from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,9 @@ path to success as it provides common base setup across various configurations.
 Usage
 -----
 
-The tests are executed by the pytest framework. For convenience, a wrapper ``run_dtests.py`` 
-is included with the intent to make starting execution of the dtests with sane defaults as easy 
-as possible. Most users will most likely find that invoking the tests directly using ``pytest`` 
-ultimately works the best and provides the most flexibility.
-
-Pytest has a great [Usage and Invocations](https://docs.pytest.org/en/latest/usage.html) document which is a great place to start for basic invocation options when using pytest.
+The tests are executed by the pytest framework which includes a helpful [Usage and
+Invocations](https://docs.pytest.org/en/latest/usage.html) document which is a great place to start
+for basic invocation options when using pytest.
 
 At minimum, 
 
@@ -83,11 +80,6 @@ environment variable (that still will have precedence if given though).
 
 Existing tests are probably the best place to start to look at how to write
 tests.
-
-The ``run_dtests.py`` included script is simply a wrapper to make starting the dtests 
-with sane defaults as simple as possible. If you just want to run the tests and do nothing more, 
-this is most likely the most easy place to start; however, anyone attempting to do active development
- and testing will find invoking pytest directly to be likely the best option.
 
 Each test spawns a new fresh cluster and tears it down after the test. If a
 test fails, the logs for the node are saved in a `logs/<timestamp>` directory


### PR DESCRIPTION
Newcomers to cassandra-dtest that look through `README.md` will see that the `run_dtests.py` script is the quickest way to get started running tests. Unfortunately, the script has a number of problems and I'm not sure it ever work properly after the move to the pytest framework.

## Process stdout/stderr buffering
Firstly, when I execute `run_dtests.py` I don't see any output after
```
$ ./run_dtests.py --dtest-tests paging_test.py 
============================= test session starts ==============================
```

This looks likely to be because of the buffering that pytest does internally for stdout and stderr and because of the way that it's executed by `run_dtests.py`, i.e. I suspect that `run_dtests.py` is blocked on the following line for most of the execution because there's no data available in the pipe for stderr:
```
stderr_output = sp.stderr.readline()
```

See also https://github.com/pytest-dev/pytest/issues/1886

## `--pytest-options` doesn't work
Secondly, the options specified in `--pytest-options` aren't actually passed through to pytest.

## Most devs run pytest directly
When I spoke to @ekaterinadimitrova2 it seemed like most developers just run the tests directly with pytest which would explain why `run_dtests.py` has bitrotted.
