### PR TITLE
CASSANDRA-16841 Fix unexpectedly ignored dtests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
   # I know we don't enforce line length but if you introduce
   # 200-char lines you are doing something terribly wrong.
   # lint all files for everything but line length errors
-  - git diff apache/trunk...HEAD -U0 | pycodestyle --ignore=E501 --diff
+  # and W503, since it is inconflict with W504
+  - git diff apache/trunk...HEAD -U0 | pycodestyle --ignore=E501,W503 --diff
   # lint all files except json_test.py for line length errors
   - git diff apache/trunk...HEAD -U0 | pycodestyle --diff --exclude='json_test.py' --exclude='meta_tests/assertion_test.py' --max-line-length=200
   - pytest --metatests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Another way to make sure that your code will pass compliance checks is to run **
 ```
 flake8 --install-hook
 git config flake8.strict true
-git config flake8.ignore E501,F811,F812,F821,F822,F823,F831,F841,N8,C9
+git config flake8.ignore E501,F811,F812,F821,F822,F823,F831,F841,N8,C9,W503
 ```
 
 We do not enforce **import** sorting, but if you choose to organize imports by some convention, use the `isort` tool (`pip install isort`).

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -28,7 +28,8 @@ since = pytest.mark.since
 ported_to_in_jvm = pytest.mark.ported_to_in_jvm
 logger = logging.getLogger(__name__)
 
-class TestBootstrap(Tester):
+
+class BootstrapTester(Tester):
     byteman_submit_path_pre_4_0 = './byteman/pre4.0/stream_failure.btm'
     byteman_submit_path_4_0 = './byteman/4.0/stream_failure.btm'
 
@@ -1097,3 +1098,13 @@ class TestBootstrap(Tester):
         # 3. check host_id in other node's table
         session1 = self.patient_exclusive_cql_connection(node1)
         assert_one(session1, "SELECT host_id FROM system.peers_v2 WHERE peer = {}".format(address2), [uuid.UUID(host_id)])
+
+
+class TestBootstrap(BootstrapTester):
+    """
+    This child class is a helper for PyTest to pick up the test methods.
+    Since the same test methods are executed as part of upgrade, this helper child class is
+    necessary to avoid double execution of the same tests.
+    It is necessary to put some dummy expression in this child class.
+    """
+    pass

--- a/conftest.py
+++ b/conftest.py
@@ -548,9 +548,12 @@ class SkipConditions:
     def __init__(self, dtest_config, sufficient_resources):
         self.skip_upgrade_tests = not dtest_config.execute_upgrade_tests and not dtest_config.execute_upgrade_tests_only
         self.skip_non_upgrade_tests = dtest_config.execute_upgrade_tests_only
-        self.skip_resource_intensive_tests = (
+        self.skip_resource_intensive_due_to_resources = (
             not dtest_config.force_execution_of_resource_intensive_tests
-            and not sufficient_resources) or dtest_config.skip_resource_intensive_tests
+            and not sufficient_resources)
+        self.skip_resource_intensive_tests = (
+            self.skip_resource_intensive_due_to_resources
+            or dtest_config.skip_resource_intensive_tests)
         self.skip_non_resource_intensive_tests = dtest_config.only_resource_intensive_tests
         self.skip_vnodes_tests = not dtest_config.use_vnodes
         self.skip_no_vnodes_tests = dtest_config.use_vnodes
@@ -606,10 +609,10 @@ def pytest_collection_modifyitems(items, config):
     sufficient_resources = sufficient_system_resources_for_resource_intensive_tests()
     skip_conditions = SkipConditions(dtest_config, sufficient_resources)
 
-    if skip_conditions.skip_resource_intensive_tests:
+    if skip_conditions.skip_resource_intensive_due_to_resources:
         logger.info("Resource intensive tests will be skipped because "
-                    "it was requested to skip or there is not enough system resource "
-                    "and --force-resource-intensive-tests were not specified")
+                    "there is not enough system resources "
+                    "and --force-resource-intensive-tests was not specified")
 
     for item in items:
         deselect_test = SkipConditions.is_skippable(skip_conditions, item)

--- a/conftest.py
+++ b/conftest.py
@@ -550,7 +550,6 @@ class SkipConditions:
         self.skip_non_upgrade_tests = dtest_config.execute_upgrade_tests_only
         self.skip_resource_intensive_tests = (
             not dtest_config.force_execution_of_resource_intensive_tests
-            and not dtest_config.only_resource_intensive_tests
             and not sufficient_resources) or dtest_config.skip_resource_intensive_tests
         self.skip_non_resource_intensive_tests = dtest_config.only_resource_intensive_tests
         self.skip_vnodes_tests = not dtest_config.use_vnodes
@@ -610,8 +609,7 @@ def pytest_collection_modifyitems(items, config):
     if skip_conditions.skip_resource_intensive_tests:
         logger.info("Resource intensive tests will be skipped because "
                     "it was requested to skip or there is not enough system resource "
-                    "and --force-resource-intensive-tests or --only-resource-intensive-tests "
-                    "were not specified")
+                    "and --force-resource-intensive-tests were not specified")
 
     for item in items:
         deselect_test = SkipConditions.is_skippable(skip_conditions, item)

--- a/conftest.py
+++ b/conftest.py
@@ -547,15 +547,13 @@ def cassandra_dir_and_version(config):
 def _is_skippable(item, mark, skip_marked, skip_non_marked):
     if item.get_closest_marker(mark) is not None:
         if skip_marked:
-            logger.info(
-                "SKIP: Skipping %s because it is marked with %s" % (item, mark))
+            logger.info("SKIP: Skipping %s because it is marked with %s" % (item, mark))
             return True
         else:
             return False
     else:
         if skip_non_marked:
-            logger.info(
-                "SKIP: Skipping %s because it is not marked with %s" % (item, mark))
+            logger.info("SKIP: Skipping %s because it is not marked with %s" % (item, mark))
             return True
         else:
             return False

--- a/meta_tests/conftest_test.py
+++ b/meta_tests/conftest_test.py
@@ -1,32 +1,29 @@
-from unittest import TestCase
+import pytest
 
-from conftest import is_skippable
+from conftest import SkipConditions, dtest_config, is_skippable
 from mock import Mock
+
+
+class DTestConfigMock():
+    def __init__(self):
+        self.execute_upgrade_tests = False
+        self.execute_upgrade_tests_only = False
+        self.force_execution_of_resource_intensive_tests = False
+        self.only_resource_intensive_tests = False
+        self.skip_resource_intensive_tests = False
+        self.use_vnodes = False
+        self.use_off_heap_memtables = False
+
+    def set(self, config):
+        if config != "":
+            setattr(self, config, True)
 
 
 def _mock_responses(responses, default_response=None):
     return lambda arg: responses[arg] if arg in responses else default_response
 
 
-def _is_skippable(item,
-                  include_upgrade_tests=True,
-                  include_non_upgrade_tests=True,
-                  include_resource_intensive_tests=True,
-                  include_non_resource_intensive_tests=True,
-                  include_vnodes_tests=True,
-                  include_no_vnodes_tests=True,
-                  include_no_offheap_memtables_tests=True):
-    return is_skippable(item,
-                        include_upgrade_tests,
-                        include_non_upgrade_tests,
-                        include_resource_intensive_tests,
-                        include_non_resource_intensive_tests,
-                        include_vnodes_tests,
-                        include_no_vnodes_tests,
-                        include_no_offheap_memtables_tests)
-
-
-class ConfTestTest(TestCase):
+class TestConfTest(object):
     regular_test = Mock(name="regular_test_mock")
     upgrade_test = Mock(name="upgrade_test_mock")
     resource_intensive_test = Mock(name="resource_intensive_test_mock")
@@ -37,37 +34,112 @@ class ConfTestTest(TestCase):
 
     def setup_method(self, method):
         self.regular_test.get_closest_marker.side_effect = _mock_responses({})
-        self.upgrade_test.get_closest_marker.side_effect = _mock_responses({"upgrade_test": True})
-        self.resource_intensive_test.get_closest_marker.side_effect = _mock_responses({"resource_intensive": True})
-        self.vnodes_test.get_closest_marker.side_effect = _mock_responses({"vnodes": True})
-        self.no_vnodes_test.get_closest_marker.side_effect = _mock_responses({"no_vnodes": True})
-        self.no_offheap_memtables_test.get_closest_marker.side_effect = _mock_responses({"no_offheap_memtables": True})
-        self.depends_driver_test.get_closest_marker.side_effect = _mock_responses({"depends_driver": True})
+        self.upgrade_test.get_closest_marker.side_effect = _mock_responses(
+            {"upgrade_test": True})
+        self.resource_intensive_test.get_closest_marker.side_effect = _mock_responses(
+            {"resource_intensive": True})
+        self.vnodes_test.get_closest_marker.side_effect = _mock_responses(
+            {"vnodes": True})
+        self.no_vnodes_test.get_closest_marker.side_effect = _mock_responses(
+            {"no_vnodes": True})
+        self.no_offheap_memtables_test.get_closest_marker.side_effect = _mock_responses(
+            {"no_offheap_memtables": True})
+        self.depends_driver_test.get_closest_marker.side_effect = _mock_responses(
+            {"depends_driver": True})
 
-    def test_regular_test(self):
-        assert not _is_skippable(item=self.regular_test)
-        assert _is_skippable(item=self.regular_test, include_non_upgrade_tests=False)
-        assert _is_skippable(item=self.regular_test, include_non_resource_intensive_tests=False)
+    @pytest.mark.parametrize("item", [upgrade_test, resource_intensive_test, vnodes_test,
+                                      depends_driver_test])
+    def test_skip_if_no_config(self, item):
+        dtest_config = DTestConfigMock()
+        assert is_skippable(item, SkipConditions(dtest_config, False))
 
-    def test_upgrade_test(self):
-        assert not _is_skippable(item=self.upgrade_test)
-        assert _is_skippable(item=self.upgrade_test, include_upgrade_tests=False)
+    @pytest.mark.parametrize("item", [regular_test, resource_intensive_test, no_vnodes_test,
+                                      no_offheap_memtables_test])
+    def test_include_if_no_config(self, item):
+        dtest_config = DTestConfigMock()
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_resource_intensive_test(self):
-        assert not _is_skippable(item=self.resource_intensive_test)
-        assert _is_skippable(item=self.resource_intensive_test, include_resource_intensive_tests=False)
+    @pytest.mark.parametrize("item,config",
+                             [(upgrade_test, "execute_upgrade_tests_only"),
+                              (resource_intensive_test, "only_resource_intensive_tests")])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_if_config_only(self, item, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert not is_skippable(item, SkipConditions(
+            dtest_config, sufficient_resources))
 
-    def test_vnodes_test(self):
-        assert not _is_skippable(item=self.vnodes_test)
-        assert _is_skippable(item=self.vnodes_test, include_vnodes_tests=False)
+    @pytest.mark.parametrize("item",
+                             [regular_test, upgrade_test, resource_intensive_test, vnodes_test,
+                              no_vnodes_test, no_offheap_memtables_test])
+    @pytest.mark.parametrize("only_item,config",
+                             [(upgrade_test, "execute_upgrade_tests_only"),
+                              (resource_intensive_test, "only_resource_intensive_tests")])
+    def test_config_only(self, item, only_item, config):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        if item != only_item:
+            assert is_skippable(item, SkipConditions(dtest_config, True))
+        else:
+            assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_no_vnodes_test(self):
-        assert not _is_skippable(item=self.no_vnodes_test)
-        assert _is_skippable(item=self.no_vnodes_test, include_no_vnodes_tests=False)
+    @pytest.mark.parametrize("item",
+                             [regular_test, upgrade_test, resource_intensive_test,
+                              no_vnodes_test, no_offheap_memtables_test])
+    def test_include_if_execute_upgrade(self, item):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("execute_upgrade_tests")
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_no_offheap_memtables_test(self):
-        assert not _is_skippable(item=self.no_offheap_memtables_test)
-        assert _is_skippable(item=self.no_offheap_memtables_test, include_no_offheap_memtables_tests=False)
+    @pytest.mark.parametrize("config, sufficient_resources",
+                             [("", False),
+                              ("skip_resource_intensive_tests", True),
+                              ("skip_resource_intensive_tests", False)])
+    def test_skip_resource_intensive(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert is_skippable(self.resource_intensive_test,
+                            SkipConditions(dtest_config, sufficient_resources))
 
-    def test_depends_driver_test(self):
-        assert _is_skippable(item=self.depends_driver_test)
+    @pytest.mark.parametrize("config", ["force_execution_of_resource_intensive_tests",
+                                        "only_resource_intensive_tests"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_resource_intensive_if_any_resources(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert not is_skippable(self.resource_intensive_test, SkipConditions(
+            dtest_config, sufficient_resources))
+
+    def test_skip_resource_intensive_wins(self):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("force_execution_of_resource_intensive_tests")
+        dtest_config.set("only_resource_intensive_tests")
+        dtest_config.set("skip_resource_intensive_tests")
+        assert is_skippable(self.resource_intensive_test,
+                            SkipConditions(dtest_config, True))
+
+    @pytest.mark.parametrize("item",
+                             [regular_test, resource_intensive_test, vnodes_test,
+                              no_offheap_memtables_test])
+    def test_if_config_vnodes(self, item):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("use_vnodes")
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
+
+    def test_skip_no_offheap_memtables(self):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("use_off_heap_memtables")
+        assert is_skippable(self.no_offheap_memtables_test,
+                            SkipConditions(dtest_config, True))
+
+    @pytest.mark.parametrize("config", ["", "execute_upgrade_tests", "execute_upgrade_tests_only",
+                                        "force_execution_of_resource_intensive_tests",
+                                        "only_resource_intensive_tests",
+                                        "skip_resource_intensive_tests", "use_vnodes",
+                                        "use_off_heap_memtables"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_skip_depends_driver_always(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert is_skippable(self.depends_driver_test, SkipConditions(
+            dtest_config, sufficient_resources))

--- a/meta_tests/conftest_test.py
+++ b/meta_tests/conftest_test.py
@@ -62,11 +62,10 @@ class TestConfTest(object):
     @pytest.mark.parametrize("item,config",
                              [(upgrade_test, "execute_upgrade_tests_only"),
                               (resource_intensive_test, "only_resource_intensive_tests")])
-    @pytest.mark.parametrize("sufficient_resources", [True, False])
-    def test_include_if_config_only(self, item, config, sufficient_resources):
+    def test_include_if_config_only(self, item, config):
         dtest_config = DTestConfigMock()
         dtest_config.set(config)
-        assert not SkipConditions(dtest_config, sufficient_resources).is_skippable(item)
+        assert not SkipConditions(dtest_config, True).is_skippable(item)
 
     @pytest.mark.parametrize("item",
                              [regular_test, upgrade_test, resource_intensive_test, vnodes_test,
@@ -100,12 +99,10 @@ class TestConfTest(object):
         dtest_config.set(config)
         assert SkipConditions(dtest_config, sufficient_resources).is_skippable(self.resource_intensive_test)
 
-    @pytest.mark.parametrize("config", ["force_execution_of_resource_intensive_tests",
-                                        "only_resource_intensive_tests"])
     @pytest.mark.parametrize("sufficient_resources", [True, False])
-    def test_include_resource_intensive_if_any_resources(self, config, sufficient_resources):
+    def test_include_resource_intensive_if_any_resources(self, sufficient_resources):
         dtest_config = DTestConfigMock()
-        dtest_config.set(config)
+        dtest_config.set("force_execution_of_resource_intensive_tests")
         assert not SkipConditions(dtest_config, sufficient_resources).is_skippable(self.resource_intensive_test)
 
     def test_skip_resource_intensive_wins(self):

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 # Also used by upgrade_tests/storage_engine_upgrade_test
 # to test loading legacy sstables
-class TestBaseSStableLoader(Tester):
+class BaseSStableLoaderTester(Tester):
 
     @pytest.fixture(autouse=True)
     def fixture_add_additional_log_patterns(self, fixture_dtest_setup):
@@ -250,7 +250,7 @@ class TestBaseSStableLoader(Tester):
                     assert 0 == len(temp_files), "Temporary files were not cleaned up."
 
 
-class TestSSTableGenerationAndLoading(TestBaseSStableLoader):
+class TestSSTableGenerationAndLoading(BaseSStableLoaderTester):
 
     def test_sstableloader_uppercase_keyspace_name(self):
         """

--- a/upgrade_tests/README.md
+++ b/upgrade_tests/README.md
@@ -144,6 +144,13 @@ Though that can be very verbose! To reduce the output a bit, you can use somethi
 This procedure is very similar to adding a single test, but requires a little bit more work.
 In the above example, the [cql_tests.py](cql_tests.py) module has already been built to do the necessary code generation covering the various upgrade paths, and that module is a good reference for seeing how the code generation works (see the end of the file).
 
+The upgrade tests need to be marked as upgrade tests to be selected for the execution. It happens
+implicitly if the test class inherits from `UpgradeTester`. If not, then the base test class,
+the test class or the test method needs to be marked with:
+```python
+@pytest.mark.upgrade_test
+```
+
 The basic module creation procedure:
 
 - Add the new module file.
@@ -151,6 +158,8 @@ The basic module creation procedure:
 - If you don't extend UpgradeTester, set ```__test__ = False```. This will prevent
 nosetests from directly running the base class as a test, since the class is intended
 to act as a template and not be directly executed.
+- If you don't extend UpgradeTester, mark the base class or each class if no base class with 
+`@pytest.mark.upgrade_test`.
 - At the end of the module, you'll query the supported upgrade manifest using
 [upgrade_manifest.py](upgrade_manifest.py):build_upgrade_pairs. Similar to [cql_tests.py](cql_tests.py) you'll probably want to combine the upgrade paths with other configurations for a more complete test matrix. Don't forget to do the class gen
 for each class in your module.

--- a/upgrade_tests/bootstrap_upgrade_test.py
+++ b/upgrade_tests/bootstrap_upgrade_test.py
@@ -1,12 +1,12 @@
 import pytest
 
-from bootstrap_test import TestBootstrap
+from bootstrap_test import BootstrapTester
 
 since = pytest.mark.since
 
 
 @pytest.mark.upgrade_test
-class TestBootstrapUpgrade(TestBootstrap):
+class TestBootstrapUpgrade(BootstrapTester):
 
     """
     @jira_ticket CASSANDRA-11841

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -35,7 +35,6 @@ since = pytest.mark.since
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.upgrade_test
 class TestCQL(UpgradeTester):
 
     def is_40_or_greater(self):

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -188,6 +188,7 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(pf.all_data(), expected_data, sort_key='value')
 
 
+@pytest.mark.upgrade_test
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -916,6 +917,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(expected_data, pf.all_data(), sort_key='sometext')
 
 
+@pytest.mark.upgrade_test
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1107,6 +1109,7 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(page3, page3expected, sort_key="mytext")
 
 
+@pytest.mark.upgrade_test
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1196,6 +1199,7 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
 
 
+@pytest.mark.upgrade_test
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when deletions occur.

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -37,7 +37,6 @@ class BasePagingTester(UpgradeTester):
         return cursor
 
 
-@pytest.mark.upgrade_test
 class TestPagingSize(BasePagingTester, PageAssertionMixin):
     """
     Basic tests relating to page size (relative to results set)
@@ -188,7 +187,6 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(pf.all_data(), expected_data, sort_key='value')
 
 
-@pytest.mark.upgrade_test
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -443,7 +441,6 @@ class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
             )
 
 
-@pytest.mark.upgrade_test
 class TestPagingData(BasePagingTester, PageAssertionMixin):
 
     def test_basic_paging(self):
@@ -917,7 +914,6 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(expected_data, pf.all_data(), sort_key='sometext')
 
 
-@pytest.mark.upgrade_test
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1109,7 +1105,6 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(page3, page3expected, sort_key="mytext")
 
 
-@pytest.mark.upgrade_test
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1199,7 +1194,6 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
 
 
-@pytest.mark.upgrade_test
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when deletions occur.

--- a/upgrade_tests/regression_test.py
+++ b/upgrade_tests/regression_test.py
@@ -20,7 +20,6 @@ since = pytest.mark.since
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.upgrade_test
 class TestForRegressions(UpgradeTester):
     """
     Catch-all class for regression tests on specific versions.

--- a/upgrade_tests/storage_engine_upgrade_test.py
+++ b/upgrade_tests/storage_engine_upgrade_test.py
@@ -4,7 +4,7 @@ import pytest
 import logging
 
 from dtest import Tester, MAJOR_VERSION_4
-from sstable_generation_loading_test import TestBaseSStableLoader
+from sstable_generation_loading_test import BaseSStableLoaderTester
 from thrift_bindings.thrift010.Cassandra import (ConsistencyLevel, Deletion,
                                            Mutation, SlicePredicate,
                                            SliceRange)
@@ -464,7 +464,7 @@ class TestBootstrapAfterUpgrade(TestStorageEngineUpgrade):
 
 @pytest.mark.upgrade_test
 @since('3.0', max_version='3.99')
-class TestLoadKaSStables(TestBaseSStableLoader):
+class TestLoadKaSStables(BaseSStableLoaderTester):
     upgrade_test = True
     upgrade_from = '2.1.20'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
@@ -472,7 +472,7 @@ class TestLoadKaSStables(TestBaseSStableLoader):
 
 @pytest.mark.upgrade_test
 @since('3.0', max_version='3.99')
-class TestLoadKaCompactSStables(TestBaseSStableLoader):
+class TestLoadKaCompactSStables(BaseSStableLoaderTester):
     upgrade_test = True
     upgrade_from = '2.1.20'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
@@ -481,7 +481,7 @@ class TestLoadKaCompactSStables(TestBaseSStableLoader):
 
 @pytest.mark.upgrade_test
 @since('3.0', max_version='3.99')
-class TestLoadLaSStables(TestBaseSStableLoader):
+class TestLoadLaSStables(BaseSStableLoaderTester):
     upgrade_test = True
     upgrade_from = '2.2.13'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
@@ -489,7 +489,7 @@ class TestLoadLaSStables(TestBaseSStableLoader):
 
 @pytest.mark.upgrade_test
 @since('3.0', max_version='3.99')
-class TestLoadLaCompactSStables(TestBaseSStableLoader):
+class TestLoadLaCompactSStables(BaseSStableLoaderTester):
     upgrade_test = True
     upgrade_from = '2.2.13'
     jvm_args = LEGACY_SSTABLES_JVM_ARGS
@@ -498,25 +498,25 @@ class TestLoadLaCompactSStables(TestBaseSStableLoader):
 
 @pytest.mark.upgrade_test
 @since('4.0', max_version='4.99')
-class TestLoadMdSStables(TestBaseSStableLoader):
+class TestLoadMdSStables(BaseSStableLoaderTester):
     upgrade_from = '3.0.17'
 
 
 @pytest.mark.upgrade_test
 @since('4.0', max_version='4.99')
-class TestLoadMdCompactSStables(TestBaseSStableLoader):
+class TestLoadMdCompactSStables(BaseSStableLoaderTester):
     upgrade_from = '3.0.17'
     test_compact = True
 
 
 @pytest.mark.upgrade_test
 @since('4.0', max_version='4.99')
-class TestLoadMdThreeOneOneSStables(TestBaseSStableLoader):
+class TestLoadMdThreeOneOneSStables(BaseSStableLoaderTester):
     upgrade_from = '3.11.3'
 
 
 @pytest.mark.upgrade_test
 @since('4.0', max_version='4.99')
-class TestLoadMdThreeOneOneCompactSStables(TestBaseSStableLoader):
+class TestLoadMdThreeOneOneCompactSStables(BaseSStableLoaderTester):
     upgrade_from = '3.11.3'
     test_compact = True


### PR DESCRIPTION
This commit fixes few unexpected behaviors, which were:
1. If any test class is marked with `resource_intensive`, then all tests
   in the file were treated as resource intensive.
2. If one test class is marked with `vnodes` and another test class is
   marked with `no_vnodes` in the same file, then all tests were
   skipped in the file.

The unexpected behaviors are due to marking all tests in a file if any 
class is assigned the mark. This commit fixes that marks on other 
classes in the file do not affect a test, which is not marked and 
neither its class. This is also applied to upgrade tests, so the code 
is simplified and behavior is unified.

Since the upgrade tests were utilizing that the marking one class is 
propagated to all classes in the file, they were revisited. In many 
cases the upgrade tests were already included, because their classes 
inherited from a class, which already was marked. In such cases 
unnecessary marks were removed.

The unit tests of `is_shippable` from `conftest.py` are changed to test
calculating skipping conditions from provided mocked configurations
instead of shipping if conditions are satisfied or not, which required
to change the underlying implementation. The unit tests are also
rewritten to be parameterized and it covers now all possible meaningful
test cases.

patch by Ruslan Fomkin; reviewed by Andrés de la Peña and Ekaterina 
Dimitrova for CASSANDRA-16841
