### PR TITLE
Relax limitations on test_multi_dc_replace_with_rf1

### DIFF
--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -547,8 +547,6 @@ class TestReplaceAddress(BaseReplaceAddressTest):
         self.replacement_node.watch_log_for("Unable to find sufficient sources for streaming range")
         assert_not_running(self.replacement_node)
 
-    @flaky
-    @pytest.mark.vnodes
     def test_multi_dc_replace_with_rf1(self):
         """
         Test that multi-dc replace works when rf=1 on each dc


### PR DESCRIPTION
test_multi_dc_replace_with_rf1 was failing without vnodes long time
ago for some now unknown reason. Now there is an empirical evidence
that the test doesn't fail any more. Thus the requirements to use
vnodes is relaxed and flaky mark is removed.

patch by Ruslan Fomkin; reviewed by ... for CASSANDRA-14196