### PR TITLE
CASSANDRA-17116: Zero-copy streaming changes

### DIFF
--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -153,8 +153,9 @@ class TestRebuild(Tester):
             r'Streaming error occurred on session with peer 127.0.0.3',
             r'Remote peer 127.0.0.3 failed stream session',
             r'Streaming error occurred on session with peer 127.0.0.3:7000',
-            r'Remote peer 127.0.0.3:7000 failed stream session',
-            r'Stream receive task .* already finished'
+            r'Remote peer /?127.0.0.3:7000 failed stream session',
+            r'Stream receive task .* already finished',
+            r'stream operation from /?127.0.0.1:.* failed'
         ]
 
         cluster = self.cluster


### PR DESCRIPTION
For the resumable rebuild test, we now are seeing additional log messages that
can be safely ignored when a failure is injected during streaming. The errors
are coming from the node 1 where the log entry reads "stream operation from
/127.0.0.1:.* failed". These are expected log entries when the failure is
injected. Also, added an optionall forward slash in the "Remote peer
127.0.0.3:7000 failed stream session" expected log entry, which was being
called out when executing the test locally.