### PR TITLE
CASSANDRA-18223

### DIFF
--- a/read_repair_test.py
+++ b/read_repair_test.py
@@ -34,6 +34,10 @@ def byteman_validate(node, script, verbose=False, opts=None):
         glob.glob(os.path.join(cdir, 'build', 'lib', 'jars', 'byteman-[0-9]*.jar'))[0],
         os.path.join(cdir, 'build', '*'),
     ]
+
+    if os.path.exists(os.path.join(cdir, 'modules', 'accord')):
+        jars.append(glob.glob(os.path.join(cdir, 'modules', 'accord', 'accord-core', 'build', 'libs', 'accord-core-[0-9].[0-9]-SNAPSHOT.jar'))[0])
+
     byteman_cmd.append(':'.join(jars))
     byteman_cmd.append('org.jboss.byteman.check.TestScript')
     byteman_cmd.append('-p')


### PR DESCRIPTION
As @maedhroz pointed out, the byteman script could not compile because `accord.messages.ReplyContext` was not found on the classpath. Therefore, I added the Accord library to the classpath and confirmed that it was fixed.