### PR TITLE
Fix native_transport_ssl_test.py::TestNativeTransportSSL::test_connect_to_ssl

### DIFF
--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -40,7 +40,7 @@ class TestNativeTransportSSL(Tester):
         except NoHostAvailable:
             pass
 
-        if cluster.version() >= '4.0':
+        if cluster.version() >= '4.0' and cluster.version() < '5.0':
             assert len(node1.grep_log("javax.net.ssl.SSLHandshakeException")) > 0, \
                     "Missing SSL handshake exception while connecting with non-SSL enabled client"
         else:


### PR DESCRIPTION
With the change in Netty, namely https://github.com/netty/netty/pull/13314, it throws NotSslRecordException