### PR TITLE
Fix upgrade_through_versions_test.py::TestUpgrade* tests 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -113,8 +113,8 @@ def pytest_configure(config):
 def sufficient_system_resources_for_resource_intensive_tests():
     mem = virtual_memory()
     total_mem_gb = mem.total / 1024 / 1024 / 1024
-    logger.info("total available system memory is %dGB" % total_mem_gb)
-    # todo kjkj: do not hard code our bound.. for now just do 9 instances at 3gb a piece
+    logger.info("total available system memory is %dGB, require 27GB for resource intensive tests" % total_mem_gb)
+    # do not hard code our bound.. for now just do 9 instances at 3gb a piece
     return total_mem_gb >= 9 * 3
 
 

--- a/run_dtests.py
+++ b/run_dtests.py
@@ -131,7 +131,7 @@ class RunDTests():
             "import sys\n"
             "sys.exit(pytest.main([{options}]))\n".format(options=original_raw_cmd_args))
         temp = NamedTemporaryFile(dir=getcwd())
-        logger.debug('Writing the following to {}:'.format(temp.name))
+        logger.debug('Writing to {} the following:\n {}'.format(temp.name, to_execute.encode("utf-8")))
 
         temp.write(to_execute.encode("utf-8"))
         temp.flush()

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -171,7 +171,7 @@ current_4_0_x = VersionMeta(name='current_4_0_x', family=CASSANDRA_4_0, variant=
 indev_4_1_x = VersionMeta(name='indev_4_1_x', family=CASSANDRA_4_1, variant='indev', version='github:apache/cassandra-4.1', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
 current_4_1_x = VersionMeta(name='current_4_1_x', family=CASSANDRA_4_1, variant='current', version='4.1.2', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
 
-indev_trunk = VersionMeta(name='indev_trunk', family=TRUNK, variant='indev', version='github:apache/trunk', min_proto_v=4, max_proto_v=5, java_versions=(11,))
+indev_trunk = VersionMeta(name='indev_trunk', family=TRUNK, variant='indev', version='github:apache/trunk', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
 # current_5_0_x = VersionMeta(name='current_5_0_x', family=CASSANDRA_5_0, variant='current', version='5.0-alpha1', min_proto_v=4, max_proto_v=5, java_versions=(11,))
 
 


### PR DESCRIPTION
Run generated upgrade_through_versions_test on pytest >7.2.0
pytest-7.2.0 changed how markers were inherited, pytest-dev/pytest#7792

Remove how internode_ssl was changing seeds to append the ssl storage port, it's not needed as the tests always already set enable_legacy_ssl_storage_port to true.