### PR TITLE
CASSANDRA-18742 followup

### DIFF
--- a/counter_test.py
+++ b/counter_test.py
@@ -10,6 +10,7 @@ from cassandra.query import SimpleStatement
 from tools.assertions import assert_invalid, assert_length_equal, assert_one
 from dtest import Tester, create_ks, create_cf, mk_bman_path
 from tools.data import rows_to_list
+from distutils.version import LooseVersion
 
 since = pytest.mark.since
 logger = logging.getLogger(__name__)
@@ -177,7 +178,10 @@ class TestCounters(Tester):
                 c counter
             )
         """
-        query = query + "WITH compression = { 'class' : 'SnappyCompressor' }"
+        if self.cluster.version() >= LooseVersion('5.0'):
+            query = query + "WITH compression = { 'class' : 'SnappyCompressor' }"
+        else:
+            query = query + "WITH compression = { 'sstable_compression' : 'SnappyCompressor' }"
 
         session.execute(query)
         time.sleep(2)

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -605,8 +605,10 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
 
         node1, = self.cluster.nodelist()
 
-        cmds = """create keyspace  CASSANDRA_7196 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} ;
+        cmds = "create keyspace  CASSANDRA_7196 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} ;"
 
+        if self.cluster.version() >= LooseVersion('5.0'):
+            cmds = cmds + """
 use CASSANDRA_7196;
 
 CREATE TABLE has_all_types (
@@ -625,7 +627,30 @@ CREATE TABLE has_all_types (
     varcharcol varchar,
     varintcol varint
 ) WITH compression = {'class':'LZ4Compressor'};
+"""
+        else:
+            cmds = cmds + """
+use CASSANDRA_7196;
 
+CREATE TABLE has_all_types (
+    num int PRIMARY KEY,
+    intcol int,
+    asciicol ascii,
+    bigintcol bigint,
+    blobcol blob,
+    booleancol boolean,
+    decimalcol decimal,
+    doublecol double,
+    floatcol float,
+    textcol text,
+    timestampcol timestamp,
+    uuidcol uuid,
+    varcharcol varchar,
+    varintcol varint
+) WITH compression = {'sstable_compression':'LZ4Compressor'};
+"""
+
+        cmds = cmds + """
 INSERT INTO has_all_types (num, intcol, asciicol, bigintcol, blobcol, booleancol,
                            decimalcol, doublecol, floatcol, textcol,
                            timestampcol, uuidcol, varcharcol, varintcol)

--- a/dtest.py
+++ b/dtest.py
@@ -307,7 +307,7 @@ def get_eager_protocol_version(cassandra_version):
 # We default to UTF8Type because it's simpler to use in tests
 def create_cf(session, name, key_type="varchar", speculative_retry=None, read_repair=None, compression=None,
               gc_grace=None, columns=None, validation="UTF8Type", compact_storage=False, compaction_strategy='SizeTieredCompactionStrategy',
-              primary_key=None, clustering=None):
+              primary_key=None, clustering=None, legacy_compression_class = False):
 
     compaction_fragment = "compaction = {'class': '%s', 'enabled': 'true'}"
     if compaction_strategy == '':
@@ -335,7 +335,10 @@ def create_cf(session, name, key_type="varchar", speculative_retry=None, read_re
         query = '%s AND CLUSTERING ORDER BY (%s)' % (query, clustering)
 
     if compression is not None:
-        query = '%s AND compression = { \'class\': \'%sCompressor\' }' % (query, compression)
+        if legacy_compression_class:
+            query = '%s AND compression = { \'sstable_compression\': \'%sCompressor\' }' % (query, compression)
+        else:
+            query = '%s AND compression = { \'class\': \'%sCompressor\' }' % (query, compression)
     else:
         # if a compression option is omitted, C* will default to lz4 compression
         query += ' AND compression = {}'

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -10,7 +10,7 @@ import logging
 from ccmlib import common as ccmcommon
 from ccmlib.node import ToolError
 
-from dtest import Tester, create_ks, create_cf, mk_bman_path, MAJOR_VERSION_4
+from dtest import Tester, create_ks, create_cf, mk_bman_path, MAJOR_VERSION_4, MAJOR_VERSION_5
 from tools.assertions import assert_all, assert_none, assert_one
 
 since = pytest.mark.since
@@ -35,10 +35,10 @@ class BaseSStableLoaderTester(Tester):
         return self.fixture_dtest_setup.cluster.version() < MAJOR_VERSION_4 and self.test_compact
 
     def create_schema(self, session, ks, compression):
+        legacy_compression_class = self.fixture_dtest_setup.cluster.version() < MAJOR_VERSION_5
         create_ks(session, ks, rf=2)
-        create_cf(session, "standard1", compression=compression, compact_storage=self.compact())
-        create_cf(session, "counter1", compression=compression, columns={'v': 'counter'},
-                  compact_storage=self.compact())
+        create_cf(session, "standard1", compression=compression, compact_storage=self.compact(), legacy_compression_class = legacy_compression_class)
+        create_cf(session, "counter1", compression=compression, columns={'v': 'counter'}, compact_storage=self.compact(), legacy_compression_class = legacy_compression_class)
 
     def skip_base_class_test(self):
         if self.__class__.__name__ != 'TestBasedSSTableLoader' and self.upgrade_from is None:


### PR DESCRIPTION
Before 18742 was in, it was possible to specify "sstable_compression" as well as "class" in compression parameters. This was true from times of 3.0 to trunk.

In 2.x, "class" was not there yet, only "sstable_compression".

When I was implementing 18742, I modified dtest.py to get rid of "sstable_compression" so it will work only with "class".

The problem with this is that when there are upgrade tests from 2.0 to 3.0 / 3.11, we create a table on 2.0 with "class" but it is not recognized yet.

The fix is to create a table with "sstable_compression" if the node is of version 2.x