### PR TITLE
Add support to specify the name of the file to use as cassandra YAML

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,8 @@ def pytest_addoption(parser):
                      help="Determines wither or not to setup clusters using vnodes for tests")
     parser.addoption("--use-off-heap-memtables", action="store_true", default=False,
                      help="Enable Off Heap Memtables when creating test clusters for tests")
+    parser.addoption("--configuration-yaml", action="store", default=None,
+                     help="The name of the cassandra configuration YAML (e.g. cassandra_latest.yaml)")
     parser.addoption("--num-tokens", action="store", default=256,
                      help="Number of tokens to set num_tokens yaml setting to when creating instances "
                           "with vnodes enabled")

--- a/dtest_config.py
+++ b/dtest_config.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 class DTestConfig:
     def __init__(self):
         self.use_vnodes = True
+        self.configuration_yaml = None
         self.use_off_heap_memtables = False
         self.num_tokens = -1
         self.data_dir_count = -1
@@ -42,6 +43,7 @@ class DTestConfig:
             return
 
         self.use_vnodes = config.getoption("--use-vnodes")
+        self.configuration_yaml = config.getoption("--configuration-yaml")
         self.use_off_heap_memtables = config.getoption("--use-off-heap-memtables")
         self.num_tokens = config.getoption("--num-tokens")
         self.data_dir_count = config.getoption("--data-dir-count-per-instance")

--- a/dtest_setup.py
+++ b/dtest_setup.py
@@ -474,6 +474,8 @@ class DTestSetup(object):
 
         if self.dtest_config.use_off_heap_memtables:
             self.cluster.set_configuration_options(values={'memtable_allocation_type': 'offheap_objects'})
+        if self.dtest_config.configuration_yaml is not None:
+            self.cluster.set_configuration_yaml(self.dtest_config.configuration_yaml)
 
         self.cluster.set_configuration_options(values)
         logger.debug("Done setting configuration options:\n" + pprint.pformat(self.cluster._config_options, indent=4))

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -277,9 +277,9 @@ class TestOfflineTools(Tester):
             hashcomputed = False
             for line in outlines:
                 if sstable in line:
-                    if "Verifying BigTableReader" in line:
+                    if re.search(re.compile(r"Verifying \w+TableReader"), line):
                         verified = True
-                    elif "Checking computed hash of BigTableReader" in line:
+                    elif re.search(re.compile(r"Checking computed hash of \w+TableReader"), line):
                         hashcomputed = True
                     else:
                         logger.debug(line)

--- a/run_dtests.py
+++ b/run_dtests.py
@@ -28,6 +28,7 @@ optional arguments:
   --dtest-print-tests-output=DTEST_PRINT_TESTS_OUTPUT        Path to file where the output of --dtest-print-tests-only should be written to (default: False)
   --pytest-options=PYTEST_OPTIONS                            Additional command line arguments to proxy directly thru when invoking pytest. (default: None)
   --dtest-tests=DTEST_TESTS                                  Comma separated list of test files, test classes, or test methods to execute. (default: None)
+  --configuration-yaml=CONFIG_FILE                           The name of the cassandra configuration YAML (e.g. cassandra_latest.yaml) (default: None)
 """
 import subprocess
 import sys

--- a/scrub_test.py
+++ b/scrub_test.py
@@ -10,6 +10,8 @@ import logging
 
 from ccmlib import common
 
+from tools.misc import ImmutableMapping
+from dtest_setup_overrides import DTestSetupOverrides
 from dtest import Tester, create_ks, create_cf
 from tools.assertions import assert_length_equal, assert_stderr_clean
 
@@ -190,7 +192,16 @@ class TestHelper(Tester):
 class TestScrubIndexes(TestHelper):
     """
     Test that we scrub indexes as well as their parent tables
+    Only valid for legacy secondary indexes
     """
+
+    @pytest.fixture(scope='function', autouse=True)
+    def fixture_dtest_setup_overrides(self, dtest_config):
+        dtest_setup_overrides = DTestSetupOverrides()
+
+        if dtest_config.cassandra_version_from_build >= '5.0':
+            dtest_setup_overrides.cluster_options = ImmutableMapping({'default_secondary_index': 'legacy_local_table'})
+        return dtest_setup_overrides
 
     def create_users(self, session):
         columns = {"password": "varchar", "gender": "varchar", "session_token": "varchar", "state": "varchar", "birth_year": "bigint"}

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -17,6 +17,8 @@ from cassandra.protocol import ConfigurationException
 from cassandra.query import BatchStatement, SimpleStatement
 
 from bootstrap_test import BootstrapTester
+from tools.misc import ImmutableMapping
+from dtest_setup_overrides import DTestSetupOverrides
 from dtest import Tester, create_ks, create_cf, mk_bman_path
 from tools.assertions import assert_bootstrap_state, assert_invalid, assert_none, assert_one, assert_row_count, \
     assert_length_equal, assert_all
@@ -25,6 +27,16 @@ from tools.misc import new_node
 
 since = pytest.mark.since
 logger = logging.getLogger(__name__)
+
+"""
+This test is only valid for legacy secondary indexes.
+"""
+@pytest.fixture()
+def fixture_dtest_setup_overrides(request, dtest_config):
+    dtest_setup_overrides = DTestSetupOverrides()
+    if dtest_config.cassandra_version_from_build >= '5.0':
+        dtest_setup_overrides.cluster_options = ImmutableMapping({'default_secondary_index': 'legacy_local_table'})
+    return dtest_setup_overrides
 
 class TestSecondaryIndexes(Tester):
 


### PR DESCRIPTION
Needed to permit latest configuration dtests.