### PR TITLE
Align tests with CASSANDRA-19335

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -79,7 +79,7 @@ class TestCompaction(Tester):
         node1.flush()
 
         table_name = 'standard1'
-        output = node1.nodetool('tablestats').stdout
+        output = node1.nodetool('tablestats -r').stdout
         if output.find(table_name) != -1:
             output = output[output.find(table_name):]
             output = output[output.find("Space used (live)"):]
@@ -92,7 +92,7 @@ class TestCompaction(Tester):
         node1.compact()
         node1.wait_for_compactions()
 
-        output = node1.nodetool('tablestats').stdout
+        output = node1.nodetool('tablestats -r').stdout
         if output.find(table_name) != -1:
             output = output[output.find(table_name):]
             output = output[output.find("Space used (live)"):]
@@ -136,7 +136,7 @@ class TestCompaction(Tester):
         node1.wait_for_compactions()
 
         table_name = 'standard1'
-        output = node1.nodetool('tablestats').stdout
+        output = node1.nodetool('tablestats -r').stdout
         output = output[output.find(table_name):]
         output = output[output.find("Bloom filter space used"):]
         bfSize = int(output[output.find(":") + 1:output.find("\n")].strip())
@@ -595,7 +595,7 @@ class TestCompaction(Tester):
             pytest.skip('DateTieredCompactionStrategy is not supported in Cassandra 5.0 and later')
 
 def grep_sstables_in_each_level(node, table_name):
-    output = node.nodetool('tablestats').stdout
+    output = node.nodetool('tablestats -r').stdout
     output = output[output.find(table_name):]
     output = output[output.find("SSTables in each level"):]
     return output[output.find(":") + 1:output.find("\n")].strip()

--- a/dtest.py
+++ b/dtest.py
@@ -422,7 +422,7 @@ def data_size(node, ks, cf):
     @return: data size in bytes
     """
     hack_legacy_parsing(node)
-    tablestats = node.nodetool("tablestats {}.{}".format(ks,cf))[0]
+    tablestats = node.nodetool("tablestats {}.{} -r".format(ks,cf))[0]
     regex = re.compile(r'[\t]')
     stats_lines = [regex.sub("", s) for s in tablestats.split('\n')
                   if regex.sub("", s).startswith('Space used (total)')]

--- a/dtest.py
+++ b/dtest.py
@@ -422,7 +422,7 @@ def data_size(node, ks, cf):
     @return: data size in bytes
     """
     hack_legacy_parsing(node)
-    tablestats = node.nodetool("tablestats {}.{} -r".format(ks,cf))[0]
+    tablestats = node.nodetool("tablestats -r {}.{}".format(ks,cf))[0]
     regex = re.compile(r'[\t]')
     stats_lines = [regex.sub("", s) for s in tablestats.split('\n')
                   if regex.sub("", s).startswith('Space used (total)')]


### PR DESCRIPTION
[CASSANDRA-19335](https://issues.apache.org/jira/browse/CASSANDRA-19335), introduced in [PR#3069](https://github.com/apache/cassandra/pull/3069), implements the following changes:
1. By default, `nodetool tablestats` now outputs byte sizes with human-readable suffixes (e.g., "bytes", "KiB", "MiB"). This update has caused several dtests to fail, as detailed in this [CircleCI report](https://app.circleci.com/pipelines/github/driftx/cassandra/1475/workflows/1dcedb48-abf2-4b45-ab0f-787830bfb21b/jobs/72781/tests).
2. A new CLI flag, `-r` or `--no-human-readable`, has been added to `nodetool tablestats` to revert to the non-human-readable byte size output, maintaining compatibility with existing parsing logic.

**Backwards Compatibility:**
- Versions of `nodetool` prior to [PR#3069](https://github.com/apache/cassandra/pull/3069) may not recognize the `-r` CLI flag, leading to potential test failures.

**Further Work:**
- Implement JSON / YAML output options for `nodetool tablestats` and update dtests to parse these formats.