### PR TITLE
Fix test failures due to CEP-37

### DIFF
--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -1201,7 +1201,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
-            AND speculative_retry = '99p';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table += """
@@ -1222,7 +1224,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
-            AND speculative_retry = '99p';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table += """
@@ -1334,7 +1338,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
-            AND speculative_retry = '99p';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table = """
@@ -1359,7 +1365,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
-            AND speculative_retry = '99p';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table = """
@@ -1383,7 +1391,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
-            AND speculative_retry = '99p';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('3.9'):
             create_table =  """
@@ -1405,7 +1415,9 @@ CREATE TYPE test.address_type (
             AND memtable_flush_period_in_ms = 0
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
-            AND speculative_retry = '99PERCENTILE';
+            AND speculative_retry = '99p'
+            AND repair_full = {'enabled': 'true'}
+            AND repair_incremental = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('3.0'):
             create_table = """
@@ -1497,7 +1509,9 @@ CREATE TYPE test.address_type (
                 AND memtable_flush_period_in_ms = 0
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
-                AND speculative_retry = '99p';
+                AND speculative_retry = '99p'
+                AND repair_full = {'enabled': 'true'}
+                AND repair_incremental = {'enabled': 'true'};
                """ % self.get_compaction() 
         elif self.cluster.version() >= LooseVersion('4.1'):
             return """
@@ -1522,7 +1536,9 @@ CREATE TYPE test.address_type (
                 AND memtable_flush_period_in_ms = 0
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
-                AND speculative_retry = '99p';
+                AND speculative_retry = '99p'
+                AND repair_full = {'enabled': 'true'}
+                AND repair_incremental = {'enabled': 'true'};
                """
         elif self.cluster.version() >= LooseVersion('4.0'):
             return """

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -1202,9 +1202,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table += """
@@ -1226,9 +1224,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table += """
@@ -1341,9 +1337,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table = """
@@ -1369,9 +1363,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table = """
@@ -1396,9 +1388,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """
         elif self.cluster.version() >= LooseVersion('3.9'):
             create_table =  """
@@ -1421,9 +1411,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair_chance = 0.0
             AND speculative_retry = '99p'
-            AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'}
-            AND repair_preview_repaired = {'enabled': 'true'};
+            AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
         """
         elif self.cluster.version() >= LooseVersion('3.0'):
             create_table = """
@@ -1516,9 +1504,7 @@ CREATE TYPE test.address_type (
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p'
-                AND repair_full = {'enabled': 'true'}
-                AND repair_incremental = {'enabled': 'true'}
-                AND repair_preview_repaired = {'enabled': 'true'};
+                AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
                """ % self.get_compaction() 
         elif self.cluster.version() >= LooseVersion('4.1'):
             return """
@@ -1544,9 +1530,7 @@ CREATE TYPE test.address_type (
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p'
-                AND repair_full = {'enabled': 'true'}
-                AND repair_incremental = {'enabled': 'true'}
-                AND repair_preview_repaired = {'enabled': 'true'};
+                AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};
                """
         elif self.cluster.version() >= LooseVersion('4.0'):
             return """

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -1203,7 +1203,8 @@ CREATE TYPE test.address_type (
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table += """
@@ -1226,7 +1227,8 @@ CREATE TYPE test.address_type (
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table += """
@@ -1340,7 +1342,8 @@ CREATE TYPE test.address_type (
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """ % self.get_compaction()
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table = """
@@ -1367,7 +1370,8 @@ CREATE TYPE test.address_type (
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
             create_table = """
@@ -1393,7 +1397,8 @@ CREATE TYPE test.address_type (
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('3.9'):
             create_table =  """
@@ -1417,7 +1422,8 @@ CREATE TYPE test.address_type (
             AND read_repair_chance = 0.0
             AND speculative_retry = '99p'
             AND repair_full = {'enabled': 'true'}
-            AND repair_incremental = {'enabled': 'true'};
+            AND repair_incremental = {'enabled': 'true'}
+            AND repair_preview_repaired = {'enabled': 'true'};
         """
         elif self.cluster.version() >= LooseVersion('3.0'):
             create_table = """
@@ -1511,7 +1517,8 @@ CREATE TYPE test.address_type (
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p'
                 AND repair_full = {'enabled': 'true'}
-                AND repair_incremental = {'enabled': 'true'};
+                AND repair_incremental = {'enabled': 'true'}
+                AND repair_preview_repaired = {'enabled': 'true'};
                """ % self.get_compaction() 
         elif self.cluster.version() >= LooseVersion('4.1'):
             return """
@@ -1538,7 +1545,8 @@ CREATE TYPE test.address_type (
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p'
                 AND repair_full = {'enabled': 'true'}
-                AND repair_incremental = {'enabled': 'true'};
+                AND repair_incremental = {'enabled': 'true'}
+                AND repair_preview_repaired = {'enabled': 'true'};
                """
         elif self.cluster.version() >= LooseVersion('4.0'):
             return """


### PR DESCRIPTION
[CEP-37](https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-37+%28DRAFT%29+Apache+Cassandra+Unified+Repair+Solution) has added the following two new table properties:
```
AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'}
```

Due to this, a couple of dtest fails. This PR fixes those dtests.

Jira: [CASSANDRA-19918](https://issues.apache.org/jira/browse/CASSANDRA-19918)