### PR TITLE
[CASSANDRA-20194] Fix TestSpeculativeReadRepair for Cassandra 5.1 by restoring the logic which forces the order of Replica objects

### DIFF
--- a/byteman/read_repair/sorted_live_endpoints.btm
+++ b/byteman/read_repair/sorted_live_endpoints.btm
@@ -1,3 +1,4 @@
+# Force 1 and 2 nodes to be used for quorum read by forcing the order of Replica objects
 RULE sorted live endpoints
 CLASS org.apache.cassandra.locator.SimpleSnitch
 METHOD sortedByProximity

--- a/byteman/read_repair/sorted_live_endpoints_5_1.btm
+++ b/byteman/read_repair/sorted_live_endpoints_5_1.btm
@@ -1,0 +1,21 @@
+# Force 1 and 2 nodes to be used for quorum read by forcing the order of Replica objects
+
+# For the case when snitch is still enabled in cassandra.yaml
+RULE sorted live endpoints
+CLASS org.apache.cassandra.locator.SimpleSnitch
+METHOD sortedByProximity
+AT ENTRY
+IF true
+DO
+return $unsortedAddress.sorted(java.util.Comparator.naturalOrder());
+ENDRULE
+
+# For the case when node_proximity is configured in cassandra_latest.yaml and SimpleSnitch is not used
+RULE sorted live endpoints
+CLASS org.apache.cassandra.locator.BaseProximity
+METHOD sortedByProximity
+AT ENTRY
+IF true
+DO
+return $unsortedAddress.sorted(java.util.Comparator.naturalOrder());
+ENDRULE

--- a/byteman/read_repair/sorted_live_endpoints_5_1.btm
+++ b/byteman/read_repair/sorted_live_endpoints_5_1.btm
@@ -1,7 +1,7 @@
 # Force 1 and 2 nodes to be used for quorum read by forcing the order of Replica objects
 
 # For the case when snitch is still enabled in cassandra.yaml
-RULE sorted live endpoints
+RULE sorted live endpoints for SimpleSnitch
 CLASS org.apache.cassandra.locator.SimpleSnitch
 METHOD sortedByProximity
 AT ENTRY
@@ -11,7 +11,7 @@ return $unsortedAddress.sorted(java.util.Comparator.naturalOrder());
 ENDRULE
 
 # For the case when node_proximity is configured in cassandra_latest.yaml and SimpleSnitch is not used
-RULE sorted live endpoints
+RULE sorted live endpoints for BaseProximity
 CLASS org.apache.cassandra.locator.BaseProximity
 METHOD sortedByProximity
 AT ENTRY

--- a/read_repair_test.py
+++ b/read_repair_test.py
@@ -544,7 +544,7 @@ class TestSpeculativeReadRepair(Tester):
         with raises(WriteTimeout):
             session.execute(quorum("INSERT INTO ks.tbl (k, c, v) VALUES (1, 1, 2)"))
 
-        node2.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        node2.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
         session = self.get_cql_connection(node2)
         with StorageProxy(node2) as storage_proxy:
             assert storage_proxy.blocking_read_repair == 0
@@ -577,7 +577,8 @@ class TestSpeculativeReadRepair(Tester):
         # re-enable writes
         node2.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
 
-        node2.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
+        node2.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
         coordinator = node2
         # Stop reads on coordinator in order to make sure we do not go through
         # the messaging service for the local reads
@@ -614,7 +615,9 @@ class TestSpeculativeReadRepair(Tester):
         # re-enable writes
         node2.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
 
-        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
+        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
+
         version = self.cluster.cassandra_version()
         if version < '4.1':
             node1.byteman_submit([mk_bman_path('request_verb_timing.btm')])
@@ -664,7 +667,7 @@ class TestSpeculativeReadRepair(Tester):
         script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
         node2.byteman_submit([mk_bman_path('read_repair/stop_rr_writes{}.btm'.format(script_version))])
 
-        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
         with StorageProxy(node1) as storage_proxy:
             assert storage_proxy.blocking_read_repair == 0
             assert storage_proxy.speculated_rr_read == 0
@@ -701,11 +704,11 @@ class TestSpeculativeReadRepair(Tester):
         node2.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
         node3.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
 
+        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
         # force endpoint order
-        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
 
         node2.byteman_submit([mk_bman_path('read_repair/stop_data_reads.btm')])
-        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
         node3.byteman_submit([mk_bman_path('read_repair/stop_rr_writes{}.btm'.format(script_version))])
 
         with StorageProxy(node1) as storage_proxy:
@@ -746,12 +749,12 @@ class TestSpeculativeReadRepair(Tester):
         node2.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
         node3.byteman_submit(['-u', mk_bman_path('read_repair/stop_writes.btm')])
 
+        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
         # force endpoint order
-        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints.btm')])
+        node1.byteman_submit([mk_bman_path('read_repair/sorted_live_endpoints{}.btm'.format(script_version))])
 
         node2.byteman_submit([mk_bman_path('read_repair/stop_digest_reads.btm')])
         node3.byteman_submit([mk_bman_path('read_repair/stop_data_reads.btm')])
-        script_version = '_5_1' if self.cluster.version() >= LooseVersion('5.1') else ''
         node2.byteman_submit([mk_bman_path('read_repair/stop_rr_writes{}.btm'.format(script_version))])
 
         with StorageProxy(node1) as storage_proxy:


### PR DESCRIPTION
fix TestSpeculativeReadRepair for Cassandra 5.1 by restoring the logic which forces the order of Replica objects

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20194