### PR TITLE
CASSANDRA-20389: Fix expected error message for too long table name

### DIFF
--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -599,7 +599,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
             err = node1.run_cqlsh(cmds=cmd, cqlsh_options=options).stderr
 
         if self.cluster.version() >= LooseVersion('4.0'):
-            assert "Keyspace name must not be empty, more than 48 characters long, or contain non-alphanumeric-underscore characters (got 'ä')" in err
+            assert 'Keyspace name must not be empty and must contain alphanumeric or underscore characters only (got "ä")' in err
         else:
             assert '"ä" is not a valid keyspace name' in err
 


### PR DESCRIPTION
https://github.com/apache/cassandra/pull/4038 changes the error message, thus the expected error message needs to be updated in tests.

Currently it's changed for all versions from 4.0. I am not sure if it will be necessary to be specific for 4.0.x.