### PR TITLE
CASSANDRA-18321 – distutils Version classes are deprecated. Use packaging.version instead

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -3,7 +3,7 @@ import string
 import time
 from collections import namedtuple
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 import re
 import pytest
 import logging

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -7,7 +7,7 @@ import threading
 import time
 import logging
 import signal
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from cassandra import ConsistencyLevel
 from cassandra.concurrent import execute_concurrent_with_args

--- a/client_network_stop_start_test.py
+++ b/client_network_stop_start_test.py
@@ -7,7 +7,7 @@ import string
 import time
 
 from ccmlib.node import TimeoutError
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from dtest import Tester
 from tools import sslkeygen
 

--- a/commitlog_test.py
+++ b/commitlog_test.py
@@ -4,7 +4,7 @@ import os
 import stat
 import struct
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 import pytest
 import logging
 

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -4,7 +4,7 @@ import re
 import string
 import tempfile
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 import pytest
 import parse
 import logging

--- a/compression_test.py
+++ b/compression_test.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 
 from dtest import create_ks
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from scrub_test import TestHelper
 from tools.assertions import assert_crc_check_chance_equal
 

--- a/configuration_test.py
+++ b/configuration_test.py
@@ -8,7 +8,7 @@ from cassandra.concurrent import execute_concurrent_with_args
 
 from dtest import Tester, create_ks
 from tools.jmxutils import (JolokiaAgent, make_mbean)
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 logger = logging.getLogger(__name__)
 ported_to_in_jvm = pytest.mark.ported_to_in_jvm

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import time
 from datetime import datetime
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 # Python 3 imports
 from itertools import zip_longest
 

--- a/counter_test.py
+++ b/counter_test.py
@@ -10,7 +10,7 @@ from cassandra.query import SimpleStatement
 from tools.assertions import assert_invalid, assert_length_equal, assert_one
 from dtest import Tester, create_ks, create_cf, mk_bman_path
 from tools.data import rows_to_list
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 since = pytest.mark.since
 logger = logging.getLogger(__name__)

--- a/cql_test.py
+++ b/cql_test.py
@@ -13,7 +13,7 @@ from cassandra.policies import FallthroughRetryPolicy
 from cassandra.query import SimpleStatement
 
 from dtest import Tester, create_ks, mk_bman_path
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from thrift_bindings.thrift010.ttypes import \
     ConsistencyLevel as ThriftConsistencyLevel
 from thrift_bindings.thrift010.ttypes import (CfDef, Column, ColumnOrSuperColumn,

--- a/cql_tracing_test.py
+++ b/cql_tracing_test.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from dtest import Tester, create_ks
 

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -16,7 +16,7 @@ import tempfile
 
 import pytest
 from decimal import Decimal
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from tempfile import NamedTemporaryFile
 from uuid import UUID, uuid4
 

--- a/cqlsh_tests/test_cqlsh_copy.py
+++ b/cqlsh_tests/test_cqlsh_copy.py
@@ -12,7 +12,7 @@ import re
 import time
 from collections import namedtuple
 from decimal import Decimal
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from tempfile import NamedTemporaryFile, gettempdir, template
 from uuid import uuid1, uuid4
 

--- a/dtest.py
+++ b/dtest.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 import traceback
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import cassandra

--- a/dtest_setup.py
+++ b/dtest_setup.py
@@ -22,7 +22,7 @@ from ccmlib.extension import get_cluster_class
 
 from dtest import (get_ip_from_node, make_execution_profile, get_auth_provider, get_port_from_node,
                    get_eager_protocol_version, hack_legacy_parsing)
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from tools.context import log_filter
 from tools.funcutils import merge_dicts

--- a/jmx_auth_test.py
+++ b/jmx_auth_test.py
@@ -2,7 +2,7 @@ import random
 import string
 import pytest
 import logging
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from ccmlib.node import ToolError
 from dtest import Tester

--- a/jmx_test.py
+++ b/jmx_test.py
@@ -8,7 +8,7 @@ import logging
 import ccmlib.common
 from ccmlib.node import ToolError
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from dtest import Tester, create_ks
 from tools.jmxutils import (JolokiaAgent, enable_jmx_ssl, make_mbean)

--- a/json_test.py
+++ b/json_test.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 import logging
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from ccmlib import common
 from ccmlib.common import is_win

--- a/materialized_views_test.py
+++ b/materialized_views_test.py
@@ -19,7 +19,7 @@ from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.cluster import Cluster
 from cassandra.query import SimpleStatement
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from dtest import Tester, get_ip_from_node, create_ks, mk_bman_path
 from tools.assertions import (assert_all, assert_crc_check_chance_equal,
                               assert_invalid, assert_none, assert_one,

--- a/paging_test.py
+++ b/paging_test.py
@@ -5,7 +5,7 @@ import logging
 
 from flaky import flaky
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from cassandra import ConsistencyLevel as CL
 from cassandra import InvalidRequest, ReadFailure, ReadTimeout

--- a/pending_range_test.py
+++ b/pending_range_test.py
@@ -9,7 +9,7 @@ from cassandra.query import SimpleStatement
 
 from dtest import Tester, create_ks, mk_bman_path
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 logger = logging.getLogger(__name__)
 

--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 
 from datetime import datetime
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from threading import Event
 
 from cassandra import ConsistencyLevel as CL

--- a/read_repair_test.py
+++ b/read_repair_test.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import glob
 import os
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/repair_tests/deprecated_repair_test.py
+++ b/repair_tests/deprecated_repair_test.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from cassandra import ConsistencyLevel
 from ccmlib.common import is_win

--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -1,5 +1,5 @@
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import re

--- a/replace_address_test.py
+++ b/replace_address_test.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/replication_test.py
+++ b/replication_test.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ iniconfig==1.1.1
 lxml==5.1.0
 mock==5.1.0
 netifaces==0.11.0
-packaging==21.3
+packaging<21
 parse==1.20.1
 pluggy==1.0.0
 psutil==5.9.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #
 # In case you want to test a patch with your own CCM branch, further to changing below CCM repo and branch name, you need to add -e flag at the beginning
 # Example: -e git+https://github.com/userb/ccm.git@cassandra-17182#egg=ccm
-git+https://github.com/apache/cassandra-ccm.git@cassandra-test#egg=ccm
+-e git+https://github.com/dkropachev/cassandra-ccm.git@dk/move-off-distutils-version#egg=ccm
 click==8.0.4
 decorator==5.1.1
 docopt==0.6.2

--- a/secondary_indexes_test.py
+++ b/secondary_indexes_test.py
@@ -3,7 +3,7 @@ import random
 import re
 import time
 import uuid
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/snapshot_test.py
+++ b/snapshot_test.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import time
 import distutils.dir_util
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/topology_test.py
+++ b/topology_test.py
@@ -1,6 +1,6 @@
 import re
 import time
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import pytest
 import logging

--- a/ttl_test.py
+++ b/ttl_test.py
@@ -6,7 +6,7 @@ import pytest
 import logging
 
 from collections import OrderedDict
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from cassandra import ConsistencyLevel, InvalidRequest
 from cassandra.query import SimpleStatement

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -7,7 +7,7 @@ import pytest
 import logging
 
 from collections import OrderedDict
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from uuid import UUID, uuid4
 
 from cassandra import ConsistencyLevel, InvalidRequest

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import logging
 import pytest

--- a/upgrade_tests/upgrade_supercolumns_test.py
+++ b/upgrade_tests/upgrade_supercolumns_test.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import os
 import pytest

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 import logging
 import operator

--- a/upgrade_tests/upgrade_udtfix_test.py
+++ b/upgrade_tests/upgrade_udtfix_test.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 
 from dtest import Tester
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 from tools.misc import add_skip
 from .upgrade_manifest import build_upgrade_pairs, CASSANDRA_3_0, RUN_STATIC_UPGRADE_MATRIX
 

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -3,7 +3,7 @@ import time
 import pytest
 import logging
 
-from distutils.version import LooseVersion
+from ccmlib.version import LooseVersion
 
 from cassandra import FunctionFailure
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-18321

