### PR TITLE
Add JDK21 support for CASSANDRA-18831

### DIFF
--- a/byteman/4.0/repair_validation_sleep.btm
+++ b/byteman/4.0/repair_validation_sleep.btm
@@ -9,5 +9,5 @@ AT ENTRY
 IF NOT flagged("done")
 DO
    flag("done");
-   Thread.sleep(60000)
+   Thread.sleep(60000L)
 ENDRULE

--- a/byteman/4.0/view_builder_task_sleep.btm
+++ b/byteman/4.0/view_builder_task_sleep.btm
@@ -7,5 +7,5 @@ METHOD buildKey
 AT ENTRY
 IF TRUE
 DO
-   Thread.sleep(50);
+   Thread.sleep(50L);
 ENDRULE

--- a/byteman/bootstrap_5s_sleep.btm
+++ b/byteman/bootstrap_5s_sleep.btm
@@ -9,5 +9,5 @@
  IF NOT flagged("done")
  DO
     flag("done");
-    Thread.sleep(5000)
+    Thread.sleep(5000L)
  ENDRULE

--- a/byteman/gossip_alive_callback_sleep.btm
+++ b/byteman/gossip_alive_callback_sleep.btm
@@ -9,5 +9,5 @@ METHOD realMarkAlive
 AT ENTRY
 IF TRUE
 DO
-   Thread.sleep(2000);
+   Thread.sleep(2000L);
 ENDRULE

--- a/byteman/post5.1/delay_streaming_for_move.btm
+++ b/byteman/post5.1/delay_streaming_for_move.btm
@@ -7,5 +7,5 @@ METHOD movementMap
 AT ENTRY
 IF TRUE
 DO
-    Thread.sleep(60000);
+    Thread.sleep(60000L);
 ENDRULE

--- a/byteman/pre4.0/repair_validation_sleep.btm
+++ b/byteman/pre4.0/repair_validation_sleep.btm
@@ -9,5 +9,5 @@ AT ENTRY
 IF NOT flagged("done")
 DO
    flag("done");
-   Thread.sleep(60000)
+   Thread.sleep(60000L)
 ENDRULE

--- a/byteman/repair_anticompaction_sleep.btm
+++ b/byteman/repair_anticompaction_sleep.btm
@@ -9,5 +9,5 @@ AT ENTRY
 IF NOT flagged("done")
 DO
    flag("done");
-   Thread.sleep(60000)
+   Thread.sleep(60000L)
 ENDRULE

--- a/byteman/slow_writes.btm
+++ b/byteman/slow_writes.btm
@@ -3,5 +3,5 @@ CLASS org.apache.cassandra.db.MutationVerbHandler
 METHOD doVerb
 AT ENTRY
 IF true
-DO Thread.sleep(60000);
+DO Thread.sleep(60000L);
 ENDRULE

--- a/byteman/sstable_open_delay.btm
+++ b/byteman/sstable_open_delay.btm
@@ -7,5 +7,5 @@ METHOD open
 AT ENTRY
 IF TRUE
 DO
-    Thread.sleep(10000);
+    Thread.sleep(10000L);
 ENDRULE

--- a/byteman/stream_5s_sleep.btm
+++ b/byteman/stream_5s_sleep.btm
@@ -9,5 +9,5 @@ AT ENTRY
 IF NOT flagged("done")
 DO
    flag("done");
-   Thread.sleep(5000)
+   Thread.sleep(5000L)
 ENDRULE

--- a/byteman/stream_sleep.btm
+++ b/byteman/stream_sleep.btm
@@ -9,5 +9,5 @@ AT ENTRY
 IF NOT flagged("done")
 DO
    flag("done");
-   Thread.sleep(60000)
+   Thread.sleep(60000L)
 ENDRULE

--- a/json_test.py
+++ b/json_test.py
@@ -10,12 +10,22 @@ import logging
 from ccmlib.version import LooseVersion
 
 from ccmlib import common
-from ccmlib.common import is_win
+from ccmlib.common import is_win, get_jdk_version_int
 
 from dtest import Tester
 
 since = pytest.mark.since
 logger = logging.getLogger(__name__)
+
+"""
+We skip a few of these tests entirely on JDK19+; the compliance with the JDK spec tightened in JDK19 to better adhere to
+the minimum required precision on mantissa format to support conversion toString() and fromString(). These tests were
+originally authored as a giant block of text we effectively string compare, combining all the data type comparisons
+together; if one changed, the entire test fails for all types. We extensively test the fundamentals underlying this in
+JsonTest.java, JsonConversionTest.java, EmptyValuesTest.java, and the other methods here, so the skipped are almost
+purely redundant. Effectively these are cqlsh tests masquerading as cassandra python dtests, leveraging standing up the
+entire stack just to test that the calcified representations of json data expected here still come out of the tools.
+"""
 
 
 def build_doc_context(tester, test_name, prepare=True, connection=None, nodes=None):
@@ -203,6 +213,9 @@ class TestToJsonSelect(Tester):
     Tests using toJson with a SELECT statement
     """
 
+    @pytest.mark.skipif(get_jdk_version_int() >= 19,
+                        reason='JDK21+ uses minimum mantissa representation for floats in scientific notation, '
+                               'causing string comparison failures. Functional correctness is covered by unit tests and in-jvm dtests.')
     def test_basic_data_types(self):
         """
         Create our schema:
@@ -306,6 +319,9 @@ class TestToJsonSelect(Tester):
         """
         run_func_docstring(tester=self, test_func=self.test_counters)
 
+    @pytest.mark.skipif(get_jdk_version_int() >= 21,
+                        reason='JDK21+ uses minimum mantissa representation for floats in scientific notation, '
+                               'causing string comparison failures. Functional correctness is covered by unit tests and in-jvm dtests.')
     def test_complex_data_types(self):
         """
         Build some user types and a schema that uses them:
@@ -463,6 +479,9 @@ class TestFromJsonUpdate(Tester):
     Tests using fromJson within UPDATE statements.
     """
 
+    @pytest.mark.skipif(get_jdk_version_int() >= 19,
+                        reason='JDK21+ uses minimum mantissa representation for floats in scientific notation, '
+                               'causing string comparison failures. Functional correctness is covered by unit tests and in-jvm dtests.')
     def test_basic_data_types(self):
         """
         Create a table with the primitive types:
@@ -846,6 +865,9 @@ class TestFromJsonInsert(Tester):
     Tests using fromJson within INSERT statements.
     """
 
+    @pytest.mark.skipif(get_jdk_version_int() >= 19,
+                        reason='JDK21+ uses minimum mantissa representation for floats in scientific notation, '
+                               'causing string comparison failures. Functional correctness is covered by unit tests and in-jvm dtests.')
     def test_basic_data_types(self):
         """
         Create a table with the primitive types:
@@ -1133,6 +1155,9 @@ class TestJsonFullRowInsertSelect(Tester):
     Tests for creating full rows from json documents, selecting full rows back as json documents, and related functionality.
     """
 
+    @pytest.mark.skipif(get_jdk_version_int() >= 19,
+                        reason='JDK21+ uses minimum mantissa representation for floats in scientific notation, '
+                               'causing string comparison failures. Functional correctness is covered by unit tests and in-jvm dtests.')
     def test_simple_schema(self):
         """
         Create schema:

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -182,7 +182,7 @@ current_4_1_x = VersionMeta(name='current_4_1_x', family=CASSANDRA_4_1, variant=
 indev_5_0_x = VersionMeta(name='indev_5_0_x', family=CASSANDRA_5_0, variant='indev', version='github:apache/cassandra-5.0', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
 current_5_0_x = VersionMeta(name='current_5_0_x', family=CASSANDRA_5_0, variant='current', version='5.0.6', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
 
-indev_trunk = VersionMeta(name='indev_trunk', family=TRUNK, variant='indev', version='github:apache/trunk', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
+indev_trunk = VersionMeta(name='indev_trunk', family=TRUNK, variant='indev', version='github:apache/trunk', min_proto_v=4, max_proto_v=5, java_versions=(11,17,21))
 # TODO – add current_5_1_x when this gets uncommented (when 5.1-alpha1 is released)
 # current_5_1_x = VersionMeta(name='current_5_1_x', family=CASSANDRA_5_1, variant='current', version='5.1-alpha1', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
 

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -983,7 +983,7 @@ for upgrade in MULTI_UPGRADES:
                 # replace matching meta with current version
                 for idx, meta in enumerate(metas):
                     if meta.matches_current_env_version_family:
-                        assert CURRENT_JAVA_VERSION in meta.java_versions, "Incompatible JDK {} for version {}".format(java_version, meta.family)
+                        assert CURRENT_JAVA_VERSION in meta.java_versions, "Incompatible JDK {} for version {}".format(CURRENT_JAVA_VERSION, meta.family)
                         newmeta = meta.clone_with_local_env_version()
                         logger.debug("{} appears applicable to current env. Overriding version from {} to {}".format(upgrade.name, meta.version, newmeta.version))
                         metas[idx] = newmeta


### PR DESCRIPTION
- Fix uninitialized java_version in upgrade_through_versions_test.py
- Add JDK21 to indev_trunk in upgrade_manifest.py
- Skip mantissa including json_test.py testcases on JDK19+
- Make byteman units explicit for sleeps